### PR TITLE
U64 usize mess fix

### DIFF
--- a/book/src/kernel/memory/index.md
+++ b/book/src/kernel/memory/index.md
@@ -15,6 +15,19 @@ Lastly we have the [virtual space] which is a very useful tool to get a virtual 
 part of the kernel directly but we know where they are located in physical space. This includes, `Memory mapped IO`, `ACPI` structures, `Multiboot` structures, etc.
 
 
+## Memory pointer types
+Another thing you might notice in the code is that we use `u64` sometimes and `usize` other times. Here is what they mean:
+
+- `u64`: This is a 64-bit unsigned integer, and it will be `64` no matter the platform.
+  It is used to represent physical addresses. Because in `x86` with `CR0.PG` bit enabled, the CPU can map
+  `40-bit` physical addresses to `32-bit` virtual addresses. And thus it can be more than `32-bit`.
+- `usize`: This is a pointer-sized unsigned integer, and it will be `32` or `64` depending on the platform.
+  It is used to represent virtual addresses, and it is the same size as a pointer on the platform.
+
+Something tangent. For filesystem operations we only use `u64`,
+as hardware drives can have easily more than `4GB` of space. without needing for the CPU to be `64-bit`.
+
+
 [physical allocator]: physical_allocator.md
 [virtual mapper]: virtual_mapper.md
 [virtual space]: virtual_space.md

--- a/book/src/kernel/memory/virtual_mapper.md
+++ b/book/src/kernel/memory/virtual_mapper.md
@@ -11,9 +11,9 @@ The main features is to map and unmap physical memory to virtual memory, and to 
 The `map` function takes 1 argument `VirtualMemoryMapEntry` which is a struct contains information about the mapping:
 ```rust
 pub struct VirtualMemoryMapEntry {
-    pub virtual_address: u64,
+    pub virtual_address: usize,
     pub physical_address: Option<u64>,
-    pub size: u64,
+    pub size: usize,
     pub flags: u64,
 }
 ```

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -41,26 +41,26 @@ pub fn init_kernel_gdt() {
             access: flags::PRESENT | flags::CODE | flags::USER | flags::dpl(KERNEL_RING),
             flags_and_limit: flags::LONG_MODE,
             ..UserDescriptorEntry::empty()
-        }) as _
+        })
     });
     manager.user_code_seg = SegmentSelector::from_index(unsafe {
         manager.gdt.push_user(UserDescriptorEntry {
             access: flags::PRESENT | flags::CODE | flags::USER | flags::dpl(USER_RING),
             flags_and_limit: flags::LONG_MODE,
             ..UserDescriptorEntry::empty()
-        }) as _
+        })
     });
     manager.kernel_data_seg = SegmentSelector::from_index(unsafe {
         manager.gdt.push_user(UserDescriptorEntry {
             access: flags::PRESENT | flags::USER | flags::WRITE | flags::dpl(KERNEL_RING),
             ..UserDescriptorEntry::empty()
-        }) as _
+        })
     });
     manager.user_data_seg = SegmentSelector::from_index(unsafe {
         manager.gdt.push_user(UserDescriptorEntry {
             access: flags::PRESENT | flags::USER | flags::WRITE | flags::dpl(USER_RING),
             ..UserDescriptorEntry::empty()
-        }) as _
+        })
     });
 
     // setup TSS
@@ -80,15 +80,14 @@ pub fn init_kernel_gdt() {
             }
             // make sure that the stack is aligned, so we can easily allocate pages
             assert!(
-                is_aligned(INTR_STACK_SIZE as _, PAGE_4K)
-                    && is_aligned(stack_start_virtual as _, PAGE_4K)
+                is_aligned(INTR_STACK_SIZE, PAGE_4K) && is_aligned(stack_start_virtual, PAGE_4K)
             );
 
             // map the stack
             virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
-                virtual_address: stack_start_virtual as u64,
+                virtual_address: stack_start_virtual,
                 physical_address: None,
-                size: INTR_STACK_SIZE as u64,
+                size: INTR_STACK_SIZE,
                 flags: virtual_memory_mapper::flags::PTE_WRITABLE,
             });
 
@@ -113,7 +112,7 @@ pub fn init_kernel_gdt() {
             base_high: ((tss_ptr >> 24) & 0xFF) as u8,
             base_upper: ((tss_ptr >> 32) & 0xFFFFFFFF) as u32,
             ..SystemDescriptorEntry::empty()
-        }) as _
+        })
     });
     drop(manager);
     // call the special `run_with` so that we get the `static` lifetime

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -52,8 +52,8 @@ use crate::{
 
 fn finish_boot() {
     let physical_pages_stats = physical_page_allocator::stats();
-    let free_mem = MemSize((physical_pages_stats.0 * PAGE_4K) as u64);
-    let used_mem = MemSize((physical_pages_stats.1 * PAGE_4K) as u64);
+    let free_mem = MemSize(physical_pages_stats.0 * PAGE_4K);
+    let used_mem = MemSize(physical_pages_stats.1 * PAGE_4K);
     // this stats is recorded at this point, meaning that we could have allocated a lot,
     //  but then it got freed we don't record that
     let HeapStats {
@@ -69,15 +69,15 @@ fn finish_boot() {
         used_mem,
         used_mem.0 as f64 / (used_mem.0 + free_mem.0) as f64 * 100.
     );
-    println!("Free heap: {}", MemSize(free_size as u64));
+    println!("Free heap: {}", MemSize(free_size));
     println!(
         "Used heap: {} ({:0.3}%)",
-        MemSize(allocated as u64),
+        MemSize(allocated),
         allocated as f64 / (heap_size) as f64 * 100.
     );
     println!(
         "From possible heap: {} ({:0.3}%)",
-        MemSize(KERNEL_HEAP_SIZE as u64),
+        MemSize(KERNEL_HEAP_SIZE),
         allocated as f64 / KERNEL_HEAP_SIZE as f64 * 100.
     );
     virtual_space::debug_blocks();

--- a/kernel/src/memory_management/kernel_heap_allocator.rs
+++ b/kernel/src/memory_management/kernel_heap_allocator.rs
@@ -43,9 +43,9 @@ impl PageAllocatorProvider<PAGE_4K> for PageAllocator {
         }
 
         virtual_memory_mapper::map_kernel(&VirtualMemoryMapEntry {
-            virtual_address: current_heap_base as u64,
+            virtual_address: current_heap_base,
             physical_address: None,
-            size: (PAGE_4K * pages) as u64,
+            size: PAGE_4K * pages,
             flags: flags::PTE_WRITABLE,
         });
 

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -114,13 +114,15 @@ pub fn align_range(addr: usize, size: usize, alignment: usize) -> (usize, usize,
 }
 
 #[inline(always)]
-pub const fn virtual2physical(addr: usize) -> usize {
-    addr - KERNEL_BASE
+pub const fn virtual2physical(addr: usize) -> u64 {
+    debug_assert!(addr >= KERNEL_BASE && addr <= KERNEL_BASE + KERNEL_MAPPED_SIZE);
+    (addr - KERNEL_BASE) as u64
 }
 
 #[inline(always)]
-pub const fn physical2virtual(addr: usize) -> usize {
-    addr + KERNEL_BASE
+pub const fn physical2virtual(addr: u64) -> usize {
+    debug_assert!(addr < KERNEL_MAPPED_SIZE as u64);
+    addr as usize + KERNEL_BASE
 }
 
 pub fn display_kernel_map() {

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -142,83 +142,87 @@ pub fn display_kernel_map() {
         "  range={:016x}..{:016x}, len={:4}  nothing",
         nothing.start,
         nothing.end,
-        MemSize(nothing.len() as u64)
+        MemSize(nothing.len())
     );
     println!(
         "  range={:016x}..{:016x}, len={:4}  kernel elf",
         kernel_elf.start,
         kernel_elf.end,
-        MemSize(kernel_elf.len() as u64)
+        MemSize(kernel_elf.len())
     );
     // inner map for the elf
     println!(
         "    range={:016x}..{:016x}, len={:4}  kernel elf text",
         kernel_elf_text.start,
         kernel_elf_text.end,
-        MemSize(kernel_elf_text.len() as u64)
+        MemSize(kernel_elf_text.len())
     );
     println!(
         "    range={:016x}..{:016x}, len={:4}  kernel elf rodata",
         kernel_elf_rodata.start,
         kernel_elf_rodata.end,
-        MemSize(kernel_elf_rodata.len() as u64)
+        MemSize(kernel_elf_rodata.len())
     );
     println!(
         "    range={:016x}..{:016x}, len={:4}  kernel elf data",
         kernel_elf_data.start,
         kernel_elf_data.end,
-        MemSize(kernel_elf_data.len() as u64)
+        MemSize(kernel_elf_data.len())
     );
     println!(
         "    range={:016x}..{:016x}, len={:4}  kernel elf bss",
         kernel_elf_bss.start,
         kernel_elf_bss.end,
-        MemSize(kernel_elf_bss.len() as u64)
+        MemSize(kernel_elf_bss.len())
     );
     println!(
         "  range={:016x}..{:016x}, len={:4}  kernel physical allocator low",
         kernel_physical_allocator_low.start,
         kernel_physical_allocator_low.end,
-        MemSize(kernel_physical_allocator_low.len() as u64)
+        MemSize(kernel_physical_allocator_low.len())
     );
     println!(
         "  range={:016x}..{:016x}, len={:4}  kernel heap",
         kernel_heap.start,
         kernel_heap.end,
-        MemSize(kernel_heap.len() as u64)
+        MemSize(kernel_heap.len())
     );
     println!(
         "  range={:016x}..{:016x}, len={:4}  interrupt stack",
         interrupt_stack.start,
         interrupt_stack.end,
-        MemSize(interrupt_stack.len() as u64)
+        MemSize(interrupt_stack.len())
     );
     println!(
         "  range={:016x}..{:016x}, len={:4}  kernel extra (virtual space)",
         kernel_extra_memory.start,
         kernel_extra_memory.end,
-        MemSize(kernel_extra_memory.len() as u64)
+        MemSize(kernel_extra_memory.len())
     );
 
     // number of bytes approx used from physical memory
     println!(
         "whole kernel physical size (startup/low): {}",
-        MemSize((KERNEL_END - KERNEL_BASE) as u64)
+        MemSize(KERNEL_END - KERNEL_BASE)
     );
     // total addressable virtual kernel memory
     println!(
         "whole kernel size: {}",
-        MemSize(u64::MAX - KERNEL_BASE as u64 + 1)
+        MemSize(usize::MAX - KERNEL_BASE + 1)
     );
 }
 
 #[repr(transparent)]
-pub struct MemSize(pub u64);
+pub struct MemSize<T>(pub T);
 
-impl fmt::Display for MemSize {
+impl<T> fmt::Display for MemSize<T>
+where
+    T: TryInto<u64> + Copy,
+    <T as TryInto<u64>>::Error: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // find the best unit
-        let mut size = self.0;
+        let mut size = self.0.try_into().unwrap();
         let mut remaining = 0;
         let mut unit = "B";
         if size >= 1024 {
@@ -255,7 +259,11 @@ impl fmt::Display for MemSize {
     }
 }
 
-impl fmt::Debug for MemSize {
+impl<T> fmt::Debug for MemSize<T>
+where
+    T: TryInto<u64> + Copy,
+    <T as TryInto<u64>>::Error: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }

--- a/kernel/src/memory_management/physical_page_allocator.rs
+++ b/kernel/src/memory_management/physical_page_allocator.rs
@@ -83,9 +83,9 @@ impl PhysicalPageAllocator {
         // because the multiboot info might be stored there by grub
         let mut physical_kernel_end = virtual2physical(align_up(kernel_elf_end(), PAGE_4K));
         let multiboot_end = align_up(
-            virtual2physical(multiboot_info.end_address() as usize) as usize,
+            virtual2physical(multiboot_info.end_address() as usize),
             PAGE_4K,
-        ) as u64;
+        );
         println!("multiboot end: {multiboot_end:x}",);
         println!(
             "physical_kernel_start: {:p}",
@@ -121,15 +121,13 @@ impl PhysicalPageAllocator {
                 && (memory.base_addr + memory.length) >= physical_kernel_end
             {
                 start_physical = physical_kernel_end;
-                end_physical =
-                    align_down(memory.base_addr as usize + memory.length as usize, PAGE_4K) as u64;
+                end_physical = align_down(memory.base_addr + memory.length, PAGE_4K);
                 self.start = physical2virtual(physical_kernel_end) as _;
             } else {
                 assert!(memory.base_addr >= physical_kernel_end);
 
-                start_physical = align_up(memory.base_addr as usize, PAGE_4K) as u64;
-                end_physical =
-                    align_down(memory.base_addr as usize + memory.length as usize, PAGE_4K) as u64;
+                start_physical = align_up(memory.base_addr, PAGE_4K);
+                end_physical = align_down(memory.base_addr + memory.length, PAGE_4K);
             }
             let mut high_mem_start = core::ptr::null_mut();
             let end_virtual = if end_physical >= virtual2physical(KERNEL_END) as _ {
@@ -196,7 +194,7 @@ impl PhysicalPageAllocator {
         let page = page as *mut FreePage;
 
         if page.is_null()
-            || !is_aligned(page as _, PAGE_4K)
+            || !is_aligned(page as usize, PAGE_4K)
             || page > unsafe { page.add(1) }
             || page >= self.end as _
             || page < self.start as _

--- a/kernel/src/memory_management/physical_page_allocator.rs
+++ b/kernel/src/memory_management/physical_page_allocator.rs
@@ -78,14 +78,14 @@ impl PhysicalPageAllocator {
     }
 
     fn init(&mut self, multiboot_info: &MultiBoot2Info) {
-        const PHYSICAL_KERNEL_START: usize = virtual2physical(KERNEL_LINK);
+        const PHYSICAL_KERNEL_START: u64 = virtual2physical(KERNEL_LINK);
         // get the end of the kernel, align, and add 5 PAGES of alignment as well
         // because the multiboot info might be stored there by grub
-        let mut physical_kernel_end: usize = virtual2physical(align_up(kernel_elf_end(), PAGE_4K));
+        let mut physical_kernel_end = virtual2physical(align_up(kernel_elf_end(), PAGE_4K));
         let multiboot_end = align_up(
-            virtual2physical(multiboot_info.end_address() as usize),
+            virtual2physical(multiboot_info.end_address() as usize) as usize,
             PAGE_4K,
-        );
+        ) as u64;
         println!("multiboot end: {multiboot_end:x}",);
         println!(
             "physical_kernel_start: {:p}",
@@ -98,7 +98,7 @@ impl PhysicalPageAllocator {
             // if its after the kernel by a lot, then panic, so we can handle it, we don't want
             // to make this more complex if we don't need to
             assert!(
-                multiboot_end - physical_kernel_end < PAGE_4K * 5,
+                multiboot_end - physical_kernel_end < PAGE_4K as u64 * 5,
                 "Multiboot is after the kernel by a lot",
             );
             physical_kernel_end = multiboot_end;
@@ -117,15 +117,15 @@ impl PhysicalPageAllocator {
             // and start after that
             let start_physical;
             let end_physical;
-            if memory.base_addr <= PHYSICAL_KERNEL_START as u64
-                && (memory.base_addr + memory.length) >= physical_kernel_end as u64
+            if memory.base_addr <= PHYSICAL_KERNEL_START
+                && (memory.base_addr + memory.length) >= physical_kernel_end
             {
-                start_physical = physical_kernel_end as u64;
+                start_physical = physical_kernel_end;
                 end_physical =
                     align_down(memory.base_addr as usize + memory.length as usize, PAGE_4K) as u64;
-                self.start = physical2virtual(physical_kernel_end as _) as _;
+                self.start = physical2virtual(physical_kernel_end) as _;
             } else {
-                assert!(memory.base_addr >= physical_kernel_end as u64);
+                assert!(memory.base_addr >= physical_kernel_end);
 
                 start_physical = align_up(memory.base_addr as usize, PAGE_4K) as u64;
                 end_physical =
@@ -136,9 +136,9 @@ impl PhysicalPageAllocator {
                 high_mem_start = KERNEL_END as *mut u8;
                 KERNEL_END as *mut u8
             } else {
-                physical2virtual(end_physical as _) as _
+                physical2virtual(end_physical) as _
             };
-            let start_virtual = physical2virtual(start_physical as _) as _;
+            let start_virtual = physical2virtual(start_physical) as _;
 
             if start_virtual < end_virtual {
                 self.end = end_virtual;

--- a/kernel/src/memory_management/virtual_memory_mapper.rs
+++ b/kernel/src/memory_management/virtual_memory_mapper.rs
@@ -386,9 +386,9 @@ impl VirtualMemoryMapper {
 
         if let Some(start_physical_address) = start_physical_address.as_mut() {
             let (aligned_start, physical_size, _) =
-                align_range(*start_physical_address as usize, *requested_size, PAGE_4K);
+                align_range(*start_physical_address, *requested_size, PAGE_4K);
             assert!(physical_size == size);
-            *start_physical_address = aligned_start as u64;
+            *start_physical_address = aligned_start;
         }
 
         // keep track of current address and size

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -422,7 +422,7 @@ impl Process {
         // we consider the program starts after an imaginary function call from the kernel
         //
         // first align it to 16 bytes
-        rsp = align_down(rsp as _, 16) as _;
+        rsp = align_down(rsp, 16);
         // second, subtract 8, the call instruction
         rsp -= 8;
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -148,9 +148,9 @@ impl Process {
         let stack_size = INITIAL_STACK_SIZE_PAGES * PAGE_4K;
         let stack_start = stack_end - stack_size;
         vm.map(&VirtualMemoryMapEntry {
-            virtual_address: stack_start as u64,
+            virtual_address: stack_start,
             physical_address: None,
-            size: stack_size as u64,
+            size: stack_size,
             flags: virtual_memory_mapper::flags::PTE_USER
                 | virtual_memory_mapper::flags::PTE_WRITABLE,
         });
@@ -220,7 +220,7 @@ impl Process {
         self.parent_id
     }
 
-    pub fn is_user_address_mapped(&self, address: u64) -> bool {
+    pub fn is_user_address_mapped(&self, address: usize) -> bool {
         self.vm.is_address_mapped(address)
     }
 
@@ -311,9 +311,9 @@ impl Process {
         if increment > 0 {
             // map the new heap
             let entry = VirtualMemoryMapEntry {
-                virtual_address: old_end as u64,
+                virtual_address: old_end,
                 physical_address: None,
-                size: increment as u64,
+                size: increment as usize,
                 flags: virtual_memory_mapper::flags::PTE_USER
                     | virtual_memory_mapper::flags::PTE_WRITABLE,
             };
@@ -322,9 +322,9 @@ impl Process {
             let new_end = old_end - increment.unsigned_abs();
             // unmap old heap
             let entry = VirtualMemoryMapEntry {
-                virtual_address: new_end as u64,
+                virtual_address: new_end,
                 physical_address: None,
-                size: increment.unsigned_abs() as u64,
+                size: increment.unsigned_abs(),
                 flags: virtual_memory_mapper::flags::PTE_USER
                     | virtual_memory_mapper::flags::PTE_WRITABLE,
             };

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -392,7 +392,7 @@ fn sys_inc_heap(all_state: &mut InterruptAllSavedState) -> SyscallResult {
         sys_arg!(0, all_state.rest => i64),
     };
 
-    if !is_aligned(increment.unsigned_abs() as usize, PAGE_4K) {
+    if !is_aligned(increment.unsigned_abs(), PAGE_4K) {
         return Err(to_arg_err!(0, SyscallArgError::InvalidHeapIncrement));
     }
 

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -88,7 +88,7 @@ fn check_ptr(arg: *const u8, len: usize) -> Result<(), SyscallArgError> {
         process.is_user_address_mapped(arg as _)
         // very basic check, just check the last byte
         // TODO: check all mapped pages
-            && process.is_user_address_mapped((arg as usize + len - 1) as _)
+            && process.is_user_address_mapped(arg as usize + len - 1 )
     }) {
         return Err(SyscallArgError::InvalidUserPointer);
     }
@@ -115,7 +115,7 @@ fn sys_arg_to_slice<'a, T: Sized>(buf: *const u8, len: usize) -> Result<&'a [T],
 
     check_ptr(buf, len * mem::size_of::<T>())?;
 
-    let slice = unsafe { core::slice::from_raw_parts(buf as _, len as _) };
+    let slice = unsafe { core::slice::from_raw_parts(buf as _, len) };
     Ok(slice)
 }
 
@@ -129,7 +129,7 @@ fn sys_arg_to_mut_slice<'a, T: Sized>(
 
     check_ptr(buf, len * mem::size_of::<T>())?;
 
-    let slice = unsafe { core::slice::from_raw_parts_mut(buf as _, len as _) };
+    let slice = unsafe { core::slice::from_raw_parts_mut(buf as _, len) };
     Ok(slice)
 }
 
@@ -337,7 +337,7 @@ fn sys_spawn(all_state: &mut InterruptAllSavedState) -> SyscallResult {
         with_current_process(|process| {
             for mapping in file_mappings {
                 process
-                    .get_fs_node(mapping.src_fd as _)
+                    .get_fs_node(mapping.src_fd)
                     .ok_or(SyscallError::InvalidFileIndex)?;
             }
             Ok::<_, SyscallError>(())
@@ -359,9 +359,9 @@ fn sys_spawn(all_state: &mut InterruptAllSavedState) -> SyscallResult {
         // take the files if any
         for mapping in file_mappings.iter() {
             let file = process
-                .take_fs_node(mapping.src_fd as _)
+                .take_fs_node(mapping.src_fd)
                 .ok_or(SyscallError::InvalidFileIndex)?;
-            new_process.attach_fs_node_to_fd(mapping.dst_fd as _, file);
+            new_process.attach_fs_node_to_fd(mapping.dst_fd, file);
             if mapping.dst_fd <= FD_STDERR {
                 std_needed[mapping.dst_fd] = false;
             }
@@ -370,10 +370,10 @@ fn sys_spawn(all_state: &mut InterruptAllSavedState) -> SyscallResult {
         // inherit files STD files if not set
         for (i, _) in std_needed.iter().enumerate().filter(|(_, &b)| b) {
             let file = process
-                .get_fs_node(i as _)
+                .get_fs_node(i)
                 .ok_or(SyscallError::InvalidFileIndex)?;
             let inherited_file = file.as_file()?.clone_inherit();
-            new_process.attach_fs_node_to_fd(i as _, inherited_file);
+            new_process.attach_fs_node_to_fd(i, inherited_file);
         }
 
         Ok::<_, SyscallError>(())


### PR DESCRIPTION
## Summary
Improve the handling of memory addresses types in the kernel, `usize` and `u64`

Also added some improvements to `align` related functions, and `MemSize`

### Related issue
Fixes #16 


## Changes
- Changed `MemSize` to use generic. Now can be `u64` or `usize` (or technically any number).
- Used `usize` for virtual addresses and `u64` for physical addresses and established documentation on this note.
- Improved `align` related functions (`is_aligned`, `align_down`...) to be implemented for `usize` and `u64`
- Because of all the above. Reduced the `as _` casts in the code.


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [ ] Needed README changes 
    - [x] not needed  
