### PR TITLE
Graphics console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "colored"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +35,29 @@ name = "compiler_builtins"
 version = "0.1.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3686cc48897ce1950aa70fd595bd2dc9f767a3c4cca4cd17b2cb52a2d37e6eb4"
+
+[[package]]
+name = "embedded-graphics"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0649998afacf6d575d126d83e68b78c0ab0e00ca2ac7e9b3db11b4cbe8274ef0"
+dependencies = [
+ "az",
+ "byteorder",
+ "embedded-graphics-core",
+ "float-cmp",
+ "micromath",
+]
+
+[[package]]
+name = "embedded-graphics-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba9ecd261f991856250d2207f6d8376946cd9f412a2165d3b75bc87a0bc7a044"
+dependencies = [
+ "az",
+ "byteorder",
+]
 
 [[package]]
 name = "emerald_kernel_user_link"
@@ -38,6 +79,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "increasing_heap_allocator"
 version = "0.1.3"
 dependencies = [
@@ -54,6 +104,7 @@ version = "0.1.0"
 name = "kernel"
 version = "0.1.0"
 dependencies = [
+ "embedded-graphics",
  "emerald_kernel_user_link",
  "increasing_heap_allocator",
 ]
@@ -63,6 +114,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "micromath"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "rustc-std-workspace-alloc"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 kernel_user_link = { version="0.2.0", path = "../libraries/kernel_user_link", package = "emerald_kernel_user_link" }
 increasing_heap_allocator = { version="0.1.3", path = "../libraries/increasing_heap_allocator" }
+embedded-graphics = { version = "0.8.1", default-features = false }

--- a/kernel/src/boot.S
+++ b/kernel/src/boot.S
@@ -30,6 +30,10 @@
 
 MULTIBOOT2_CHECK_MAGIC = 0x36d76289
 
+FRAMEBUFFER_WIDTH = 1280
+FRAMEBUFFER_HEIGHT = 720
+FRAMEBUFFER_BPP = 32
+
 PHY_PAGE_SIZE_4K = 0x1000
 PHY_PAGE_SIZE_2M = 0x200000
 PAGE_TABLE_ALLOC_PAGES = 4  # only need 4
@@ -121,6 +125,15 @@ mb2_header_start:
         .short 0 # flags
         .long mb2_module_align_tag_end - mb2_module_align_tag_start # size
     mb2_module_align_tag_end:
+    .align 8
+    mb2_framebuffer_tag_start:
+        .short 5 # type (framebuffer)
+        .short 0 # flags
+        .long mb2_framebuffer_tag_end - mb2_framebuffer_tag_start # size
+        .long FRAMEBUFFER_WIDTH
+        .long FRAMEBUFFER_HEIGHT
+        .long FRAMEBUFFER_BPP
+    mb2_framebuffer_tag_end:
     .align 8
     mb2_end_tag_start:
         .short 0 # type (end)

--- a/kernel/src/io/console.rs
+++ b/kernel/src/io/console.rs
@@ -1,3 +1,4 @@
+mod vga_graphics;
 mod vga_text;
 
 use core::fmt::{self, Write};
@@ -11,7 +12,10 @@ use crate::{
     sync::spin::mutex::Mutex,
 };
 
-use self::vga_text::{VgaText, DEFAULT_ATTRIB};
+use self::{
+    vga_graphics::VgaGraphics,
+    vga_text::{VgaText, DEFAULT_ATTRIB},
+};
 
 use super::{
     keyboard::{self, Keyboard},
@@ -61,7 +65,7 @@ fn create_video_console(framebuffer: Option<multiboot2::Framebuffer>) -> Box<dyn
     match framebuffer {
         Some(framebuffer) => match framebuffer.color_info {
             FramebufferColorInfo::Indexed { .. } => todo!(),
-            FramebufferColorInfo::Rgb { .. } => todo!(),
+            FramebufferColorInfo::Rgb { .. } => Box::new(VgaGraphics::new(framebuffer)),
             FramebufferColorInfo::EgaText => Box::new(VgaText::new(framebuffer)),
         },
         None => panic!("No framebuffer provided"),

--- a/kernel/src/io/console/vga_graphics.rs
+++ b/kernel/src/io/console/vga_graphics.rs
@@ -1,0 +1,176 @@
+use embedded_graphics::{
+    draw_target::DrawTarget,
+    geometry::{OriginDimensions, Point},
+    mono_font::{ascii::FONT_9X15, MonoTextStyle},
+    pixelcolor::{Rgb888, RgbColor},
+    text::{renderer::TextRenderer, Baseline},
+    Pixel,
+};
+
+use crate::{memory_management::virtual_space, multiboot2};
+
+use super::VideoConsole;
+
+const TEXT_STYLE: MonoTextStyle<Rgb888> = MonoTextStyle::new(&FONT_9X15, Rgb888::WHITE);
+
+pub(super) struct VgaGraphics {
+    pitch: usize,
+    height: usize,
+    width: usize,
+    field_pos: (u8, u8, u8),
+    mask: (u8, u8, u8),
+    byte_per_pixel: u8,
+    memory: &'static mut [u8],
+
+    pos: Point,
+}
+
+impl VgaGraphics {
+    pub fn new(framebuffer: multiboot2::Framebuffer) -> Self {
+        let multiboot2::FramebufferColorInfo::Rgb {
+            red_field_position,
+            red_mask_size,
+            green_field_position,
+            green_mask_size,
+            blue_field_position,
+            blue_mask_size,
+        } = framebuffer.color_info
+        else {
+            panic!("Only RGB framebuffer is supported");
+        };
+
+        let physical_addr = framebuffer.addr;
+        let memory_size = framebuffer.pitch * framebuffer.height;
+        let memory_addr =
+            virtual_space::allocate_and_map_virtual_space(physical_addr, memory_size as usize)
+                as *mut u8;
+        let memory = unsafe { core::slice::from_raw_parts_mut(memory_addr, memory_size as usize) };
+
+        let red_mask = (1 << red_mask_size) - 1;
+        let green_mask = (1 << green_mask_size) - 1;
+        let blue_mask = (1 << blue_mask_size) - 1;
+        Self {
+            pitch: framebuffer.pitch as usize,
+            height: framebuffer.height as usize,
+            width: framebuffer.width as usize,
+            field_pos: (
+                red_field_position as u8 / 8,
+                green_field_position as u8 / 8,
+                blue_field_position as u8 / 8,
+            ),
+            mask: (red_mask as u8, green_mask as u8, blue_mask as u8),
+            byte_per_pixel: (framebuffer.bpp + 7) / 8,
+            memory,
+            pos: Point::new(0, 0),
+        }
+    }
+
+    fn get_arr_pos(&self, pos: (usize, usize)) -> usize {
+        pos.0 * self.byte_per_pixel as usize + pos.1 * self.pitch
+    }
+
+    pub fn put_pixel(&mut self, x: usize, y: usize, color: Rgb888) {
+        let i = self.get_arr_pos((x, y));
+        let pixel_mem = &mut self.memory[i..i + self.byte_per_pixel as usize];
+
+        let r = color.r() & self.mask.0;
+        let g = color.g() & self.mask.1;
+        let b = color.b() & self.mask.2;
+        pixel_mem[self.field_pos.0 as usize] = r;
+        pixel_mem[self.field_pos.1 as usize] = g;
+        pixel_mem[self.field_pos.2 as usize] = b;
+    }
+
+    pub fn clear(&mut self) {
+        self.memory.fill(0);
+    }
+
+    pub fn clear_current_text_line(&mut self) {
+        let start = self.get_arr_pos((0, self.pos.y as usize));
+        let line_chunk_size = self.pitch * TEXT_STYLE.line_height() as usize;
+        self.memory[start..start + line_chunk_size].fill(0);
+    }
+
+    fn scroll(&mut self, lines: usize) {
+        let chunk_size = self.pitch * lines;
+
+        let mut i = 0;
+        while i < self.height - lines * 2 {
+            // copy chunks of height (lines) each time
+            let copy_to_start = self.get_arr_pos((0, i));
+            let copy_from_start = self.get_arr_pos((0, i + lines));
+            let (before, after) = self.memory.split_at_mut(copy_from_start);
+
+            before[copy_to_start..copy_to_start + chunk_size].copy_from_slice(&after[..chunk_size]);
+            i += lines;
+        }
+        self.pos.y -= lines as i32;
+    }
+
+    fn fix_after_advance(&mut self) {
+        if self.pos.x >= self.width as i32 {
+            self.pos.x = 0;
+            self.pos.y += TEXT_STYLE.line_height() as i32;
+        }
+        if self.pos.y + TEXT_STYLE.line_height() as i32 >= self.height as i32 {
+            // scroll up
+            self.scroll(TEXT_STYLE.line_height() as usize);
+
+            // clear line
+            self.clear_current_text_line();
+            // just to make sure we are not out of bounds by more than 1 line
+            self.fix_after_advance();
+        }
+    }
+}
+
+impl DrawTarget for VgaGraphics {
+    type Color = Rgb888;
+
+    type Error = ();
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = embedded_graphics::prelude::Pixel<Self::Color>>,
+    {
+        for Pixel(pos, color) in pixels {
+            self.put_pixel(pos.x as usize, pos.y as usize, color);
+        }
+        Ok(())
+    }
+}
+
+impl OriginDimensions for VgaGraphics {
+    fn size(&self) -> embedded_graphics::geometry::Size {
+        embedded_graphics::geometry::Size::new(self.width as u32, self.height as u32)
+    }
+}
+
+impl VideoConsole for VgaGraphics {
+    fn init(&mut self) {
+        self.clear();
+    }
+
+    fn write_byte(&mut self, c: u8) {
+        if c == b'\n' {
+            self.pos = Point::new(0, self.pos.y + TEXT_STYLE.line_height() as i32);
+        } else {
+            let mut dst = [0; 4];
+            let str = (c as char).encode_utf8(&mut dst);
+
+            self.pos = TEXT_STYLE
+                .draw_string(str, self.pos, Baseline::Bottom, self)
+                .unwrap();
+        }
+        self.fix_after_advance();
+    }
+
+    fn set_attrib(&mut self, _attrib: u8) {
+        // TODO: implement
+    }
+
+    fn get_attrib(&self) -> u8 {
+        // TODO: implement
+        0
+    }
+}

--- a/kernel/src/io/mod.rs
+++ b/kernel/src/io/mod.rs
@@ -3,7 +3,6 @@ use core::{fmt, sync::atomic::AtomicBool};
 pub mod console;
 pub mod keyboard;
 mod uart;
-mod video_memory;
 
 static PRINT_ERR: AtomicBool = AtomicBool::new(false);
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -134,7 +134,7 @@ pub extern "C" fn kernel_main(multiboot_info: &MultiBoot2Info) -> ! {
     // and interrupts should be disabled until
     unsafe { cpu::set_interrupts() };
     devices::init_legacy_devices();
-    console::init_late_device();
+    console::init_late_device(multiboot_info.framebuffer());
     devices::prope_pci_devices();
     fs::create_disk_mapping(0).expect("Could not load filesystem");
     finish_boot();

--- a/kernel/src/sync/spin/remutex.rs
+++ b/kernel/src/sync/spin/remutex.rs
@@ -57,6 +57,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 impl<T> ReMutex<T> {
     pub const fn new(data: T) -> Self {
         Self {


### PR DESCRIPTION
## Summary
Modified the console code a bit and this is what changed:
- `EarlyConsole` is only doing serial (uart), and no graphics for simpliciy.
- Added `VgaGraphics` console that will use `embedded_graphics` crate to draw text directly on vga framebuffer,
  we also still have `VgaText` console if booted in text mode.
- Boot now requests graphics mode from multiboot2, so we should get that almost always unless the system doesn't support for some reason?
- In `Console` switched to using `Mutex` instead of `ReMutex<RefCell<>>` its a bit easier to type, the downside is that its not possible to `print` inside the `console` code path, but we can use the debugger in that case.

### Related issue

Fixes #36 


## Changes
- Added `VgaGraphics` console, where we draw text using `embedded_graphics`.
- Switch to boot using `graphics` mode if possible, i.e. we request from multiboot2 that.

## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [ ] Documentation
    - [x] The book doesn't mention specific implementation for the console, so this PR doesn't change that.
- [ ] Needed README changes
    - [x] no need 
