### PR TITLE
Safe virtual space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ version = "0.1.0"
 name = "kernel"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "embedded-graphics",
  "emerald_kernel_user_link",
  "increasing_heap_allocator",

--- a/book/src/kernel/memory/virtual_space.md
+++ b/book/src/kernel/memory/virtual_space.md
@@ -9,7 +9,10 @@ This is useful for reading structures that are in specific location in physical 
 
 Its very simple, it will take memory from the `kernel extra` space, and map it to the physical address.
 
-It can be used by [`allocate_and_map_virtual_space`][allocate_and_map_virtual_space] and [`deallocate_virtual_space`][deallocate_virtual_space], which allow mapping and unmapping of virtual space.
+It can be used by [`VirtualSpace`][virtual_space_struct], which is similar to `Box`, i.e. its a wrapper for a pointer, and it will automatically unmap the memory when it goes out of scope.
 
-Currently its very basic and will return a number pointer, which should be `unsafe` XD, but I'm planning
-to make it a safer API.
+```rust
+let mut vs = unsafe { VirtualSpace::<u32>::new(0x1000).unwrap() };
+*vs = 0x1234;
+assert_eq!(*vs, 0x1234);
+```

--- a/book/src/links.md.template
+++ b/book/src/links.md.template
@@ -1,8 +1,7 @@
 [Kernel rust documentation]: {ROOT_PATH}docs/kernel/
 [kernel_memory_layout]: {ROOT_PATH}docs/kernel/memory_management/memory_layout
 [kernel_virtual_space]: {ROOT_PATH}docs/kernel/memory_management/virtual_space
-[allocate_and_map_virtual_space]: {ROOT_PATH}docs/kernel/memory_management/virtual_space/fn.allocate_and_map_virtual_space
-[deallocate_virtual_space]: {ROOT_PATH}docs/kernel/memory_management/virtual_space/fn.deallocate_virtual_space
+[virtual_space_struct]: {ROOT_PATH}docs/kernel/memory_management/virtual_space/struct.VirtualSpace.html
 [get_virtual_for_physical]: {ROOT_PATH}docs/kernel/memory_management/virtual_space/fn.get_virtual_for_physical
 [physical_page_allocator]: {ROOT_PATH}docs/kernel/memory_management/physical_page_allocator
 [virtual_memory_mapper]: {ROOT_PATH}docs/kernel/memory_management/virtual_memory_mapper

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 kernel_user_link = { version="0.2.0", path = "../libraries/kernel_user_link", package = "emerald_kernel_user_link" }
 increasing_heap_allocator = { version="0.1.3", path = "../libraries/increasing_heap_allocator" }
 embedded-graphics = { version = "0.8.1", default-features = false }
+byteorder = { version = "1.5", default-features = false }

--- a/kernel/src/io/console/vga_graphics.rs
+++ b/kernel/src/io/console/vga_graphics.rs
@@ -13,7 +13,7 @@ use embedded_graphics::{
     Pixel,
 };
 
-use crate::{memory_management::virtual_space, multiboot2};
+use crate::{memory_management::virtual_space::VirtualSpace, multiboot2};
 
 use super::{VideoConsole, VideoConsoleAttribute};
 
@@ -24,7 +24,7 @@ pub(super) struct VgaGraphics {
     field_pos: (u8, u8, u8),
     mask: (u8, u8, u8),
     byte_per_pixel: u8,
-    memory: &'static mut [u8],
+    memory: VirtualSpace<[u8]>,
 
     pos: Point,
     text_style: MonoTextStyle<'static, Rgb888>,
@@ -46,10 +46,8 @@ impl VgaGraphics {
 
         let physical_addr = framebuffer.addr;
         let memory_size = framebuffer.pitch * framebuffer.height;
-        let memory_addr =
-            virtual_space::allocate_and_map_virtual_space(physical_addr, memory_size as usize)
-                as *mut u8;
-        let memory = unsafe { core::slice::from_raw_parts_mut(memory_addr, memory_size as usize) };
+        let memory =
+            unsafe { VirtualSpace::new_slice(physical_addr, memory_size as usize).unwrap() };
 
         let red_mask = (1 << red_mask_size) - 1;
         let green_mask = (1 << green_mask_size) - 1;

--- a/kernel/src/io/console/vga_text.rs
+++ b/kernel/src/io/console/vga_text.rs
@@ -1,7 +1,7 @@
 //! A temporary tool to allow for easy printing to the screen.
 //! We are using the VGA text mode buffer to print to the screen.
 
-use crate::{memory_management::virtual_space, multiboot2};
+use crate::{memory_management::virtual_space::VirtualSpace, multiboot2};
 
 use super::{VideoConsole, VideoConsoleAttribute};
 
@@ -14,7 +14,7 @@ pub(super) struct VgaText {
     pitch: usize,
     height: usize,
     width: usize,
-    memory: &'static mut [u8],
+    memory: VirtualSpace<[u8]>,
 }
 
 impl VgaText {
@@ -25,10 +25,8 @@ impl VgaText {
         ));
         let physical_addr = framebuffer.addr;
         let memory_size = framebuffer.pitch * framebuffer.height;
-        let memory_addr =
-            virtual_space::allocate_and_map_virtual_space(physical_addr, memory_size as usize)
-                as *mut u8;
-        let memory = unsafe { core::slice::from_raw_parts_mut(memory_addr, memory_size as usize) };
+        let memory =
+            unsafe { VirtualSpace::new_slice(physical_addr, memory_size as usize).unwrap() };
 
         Self {
             pos: (0, 0),

--- a/kernel/src/memory_management/virtual_space.rs
+++ b/kernel/src/memory_management/virtual_space.rs
@@ -44,9 +44,11 @@ pub struct VirtualSpace<T: ?Sized> {
 }
 
 impl<T> VirtualSpace<T> {
+    /// Create a new virtual space for the given `physical_start` on the given type `T`.
+    ///
     /// # Safety
     /// - Must be a valid physical address
-    /// - The memory must be defined by default. if its not, use [`VirtualSpace::new_uninit`] instead
+    /// - The memory must be defined by default. if its not, use [`new_uninit`](Self::new_uninit) instead
     pub unsafe fn new(physical_start: u64) -> Result<Self> {
         let size = core::mem::size_of::<T>();
         let virtual_start = allocate_and_map_virtual_space(physical_start, size)?;
@@ -54,6 +56,9 @@ impl<T> VirtualSpace<T> {
         Ok(Self { size, data })
     }
 
+    /// Create a new virtual space for the given `physical_start` on the given type `T`.
+    /// But will assume that the memory is not initialized, and will return a `MaybeUninit` pointer.
+    ///
     /// # Safety
     /// - Must be a valid physical address
     #[allow(dead_code)]
@@ -67,6 +72,11 @@ impl<T> VirtualSpace<T> {
         })
     }
 
+    /// Create a new virtual space for the given `physical_start` on the given slice type `[T]`.
+    ///
+    /// # Safety
+    /// - Must be a valid physical address
+    /// - The memory must be defined by default. currently, there is no way to create a slice of `MaybeUninit`
     pub unsafe fn new_slice(physical_start: u64, len: usize) -> Result<VirtualSpace<[T]>> {
         let size = core::mem::size_of::<T>() * len;
         let virtual_start = allocate_and_map_virtual_space(physical_start, size)?;


### PR DESCRIPTION
## Summary
Added a safe api around `virtual space`, its `VirtualSpace` struct, acts similar to `Box` and will allow usage of dynamic memory that is attached to a predefined physical address.

There are several changes that we can now perform to improve the structs further (specifically APIC), which we will do next.

### Related issue
Fixes #50 


## Changes
- Added `VirtualSpace` as a safe API around `virtual space` functionalities.


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [ ] Needed README changes
    - [x] Not needed
