### PR TITLE
Once lock initialization fixes

### DIFF
--- a/kernel/src/sync/once.rs
+++ b/kernel/src/sync/once.rs
@@ -21,6 +21,7 @@ impl Once {
         }
     }
 
+    #[inline(always)]
     fn is_completed(&self) -> bool {
         self.state.load(Ordering::Relaxed) == ONCE_STATE_DONE
     }


### PR DESCRIPTION
## Summary
Small PR to improve static variables by using `OnceLock` and not have a static undefined value.

### Related issue

Fixes #55 


## Changes
- Used `OnceLock` in:
    - APIC
    - Interrupts
    - VirtualMemory
    - PhysicalAllocator

## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [ ] Documentation
  - [x] no need
- [ ] Needed README changes
  - [x] no need