### PR TITLE
Graphics driver: VGA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphics"
+version = "0.1.0"
+dependencies = [
+ "embedded-graphics",
+ "emerald_std",
+]
+
+[[package]]
 name = "increasing_heap_allocator"
 version = "0.1.3"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "emerald_kernel_user_link"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "emerald_std"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "compiler_builtins",
  "emerald_kernel_user_link",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 resolver = "2"
 default-members = ["kernel"]
 members = [
-    "libraries/kernel_user_link",
     "kernel",
-    "userspace/init", "userspace/shell", "libraries/increasing_heap_allocator", "libraries/emerald_std",
+    "libraries/kernel_user_link", "libraries/increasing_heap_allocator", "libraries/emerald_std",
+    "userspace/init", "userspace/shell", "userspace/graphics",
 ]
 
 exclude = ["extern"]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 **Emerald** is an OS written in [Rust] from scratch.
 
-The plan is to learn everything about the kernel and low level details, so I'm not using any libraries, even though
-there are a lot of good libraries that do everything I'm doing (ex. handling GDT/IDT/etc...).
+The plan is to learn everything about the kernel and low level details, so I'm implementing as much as
+possible without using any libraries.
 But maybe I'll add those just to make the code smaller and better to work with.
 
 ## Running

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,8 @@
         - [RTC](./kernel/clocks/rtc.md)
         - [HPET](./kernel/clocks/hpet.md)
         - [TSC](./kernel/clocks/tsc.md)
+    - [Graphics](./kernel/graphics/index.md)
+        - [VGA](./kernel/graphics/vga.md)
 - [Userspace](./userspace/index.md)
     - [Programs](./userspace/programs.md)
     - [Libraries](./userspace/libraries.md)

--- a/book/src/kernel/graphics/index.md
+++ b/book/src/kernel/graphics/index.md
@@ -1,0 +1,10 @@
+{{ #include ../../links.md }}
+
+# Graphics
+
+Currently, we only have a VGA driver implemented, in [VGA](./vga.md).
+
+It only has CPU based rendering, and only copies the images to vga framebuffer provided to us by the hardware.
+
+There is no hardware acceleration yet.
+

--- a/book/src/kernel/graphics/vga.md
+++ b/book/src/kernel/graphics/vga.md
@@ -1,0 +1,40 @@
+{{ #include ../../links.md }}
+
+# VGA
+
+> This is implemented in [`vga`][vga].
+
+This is a basic graphics driver implementation.
+
+We take the framebuffer info from `multiboot2` structure coming from [boot](../boot.md), 
+and use it to write to that memory, which is then displayed on the screen.
+
+This framebuffer is controlled by the kernel, the kernel can use it internally to display stuff, for example the [console](../virtual_devices/console.md) uses it to display characters on the screen.
+
+But then, the userspace processes can take ownership of the framebuffer, what this means is that the kernel
+will stop rendering to it, but still owns the memory region. At this stage the kernel will just stay there waiting
+for rendering commands coming from the owner process.
+
+The rendering commands here are just `Blit`, which is an operation that copies a region from one framebuffer
+(user allocated) to another (the vga framebuffer, that the kernel owns).
+
+Which means that all the rendering is done by the userspace processes, and the kernel just copies 
+the images to the screen.
+
+Userspace processes can be more efficient by telling the kernel which regions of the framebuffer have changed
+and only sending those regions to the kernel, so the kernel can copy only the changed regions to the screen.
+
+These operations are accessible by the [`graphics` syscall](../processes/syscalls.md#syscalls-list)
+
+## Graphics Command
+There are 4 commands supported:
+- `TakeOwnership`: This is used to take ownership of the graphics device.
+- `ReleaseOwnership`: This is used to release ownership of the graphics device, and is executed automatically when the process exits if it was not released manually.
+- `GetFrameBufferInfo(&mut info_out)`: This is used to get information about the framebuffer, see [FrameBufferInfo](https://docs.rs/emerald_std/latest/emerald_std/graphics/struct.FrameBufferInfo.html).
+- `Blit(&BlitCommand)`: This is used to blit a region from userspace memory into the graphics framebuffer, it can control (See [BlitCommand](https://docs.rs/emerald_std/latest/emerald_std/graphics/struct.BlitCommand.html) for more info):
+    - `src_framebuffer`: memory reference to the source framebuffer (only read by the kernel)
+    - `src_framebuffer_info`: The framebuffer info of the source framebuffer, i.e. its shape in the memory, so that
+      we can copy correctly from it.
+    - `src_x`, `src_y`: The top-left corner of the source region (user memory)
+    - `dest_x`, `dest_y`: The top-left corner of the destination region (kernel)
+    - `width`, `height`: The width and height of the region to copy, applies to both

--- a/book/src/kernel/processes/syscalls.md
+++ b/book/src/kernel/processes/syscalls.md
@@ -47,3 +47,4 @@ these pointers/values to the correct types.
 | `get_file_meta` | `file_index: usize, meta_id: u64, meta_data: *mut u64` | `()` | Gets the file meta |
 | `sleep` | `seconds: u64, nanos: u64` | `()` | Sleeps for a duration |
 | `get_time` | `clock_type: ClockType, time: *mut ClockTime` | `()` | Gets the time based on the `clock_type`, see [Clocks](../clocks/index.md) |
+| `graphics` | `command: GraphicsCommand, extra: *mut ()` | `()` | Graphics operations, see [Graphics:VGA](../graphics/vga.md#graphics-command) |

--- a/book/src/links.md.template
+++ b/book/src/links.md.template
@@ -41,3 +41,5 @@
 [rtc]: {ROOT_PATH}docs/kernel/devices/clock/rtc
 [tsc]: {ROOT_PATH}docs/kernel/devices/clock/tsc
 [clocks]: {ROOT_PATH}docs/kernel/devices/clock
+[vga]: {ROOT_PATH}docs/kernel/graphics/vga
+[framebufferinfo]: {ROOT_PATH}docs/kernel/graphics/vga/struct.FrameBufferInfo.html

--- a/kernel/src/graphics/mod.rs
+++ b/kernel/src/graphics/mod.rs
@@ -1,0 +1,21 @@
+use embedded_graphics::pixelcolor::RgbColor;
+
+pub mod vga;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pixel {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl<T: RgbColor> From<T> for Pixel {
+    fn from(color: T) -> Self {
+        Self {
+            r: color.r(),
+            g: color.g(),
+            b: color.b(),
+        }
+    }
+}

--- a/kernel/src/graphics/vga.rs
+++ b/kernel/src/graphics/vga.rs
@@ -1,0 +1,413 @@
+use core::sync::atomic::{AtomicI64, Ordering};
+
+use embedded_graphics::{
+    draw_target::DrawTarget,
+    geometry::{self, OriginDimensions},
+    pixelcolor::Rgb888,
+};
+
+use crate::{
+    memory_management::virtual_space::VirtualSpace,
+    multiboot2::{self, FramebufferColorInfo},
+    sync::{
+        once::OnceLock,
+        spin::mutex::{Mutex, MutexGuard},
+    },
+};
+
+use super::Pixel;
+
+static VGA_DISPLAY_CONTROLLER: OnceLock<VgaDisplayController> = OnceLock::new();
+
+pub fn init(framebuffer: Option<multiboot2::Framebuffer>) {
+    if VGA_DISPLAY_CONTROLLER.try_get().is_some() {
+        panic!("VGA display controller already initialized");
+    }
+
+    match framebuffer {
+        Some(framebuffer) => match framebuffer.color_info {
+            FramebufferColorInfo::Indexed { .. } => {}
+            FramebufferColorInfo::Rgb { .. } => {
+                // only initialize if the framebuffer is RGB
+                VGA_DISPLAY_CONTROLLER.get_or_init(|| VgaDisplayController::new(framebuffer));
+            }
+            FramebufferColorInfo::EgaText => {}
+        },
+        None => panic!("No framebuffer provided"),
+    }
+}
+
+pub fn controller() -> Option<&'static VgaDisplayController> {
+    VGA_DISPLAY_CONTROLLER.try_get()
+}
+
+pub struct VgaDisplayController {
+    display: Mutex<VgaDisplay>,
+    framebuffer_info: FrameBufferInfo,
+    owner_process: AtomicI64,
+}
+
+#[allow(dead_code)]
+impl VgaDisplayController {
+    pub fn new(framebuffer: multiboot2::Framebuffer) -> Self {
+        let display = VgaDisplay::new(framebuffer);
+
+        Self {
+            framebuffer_info: display.fb_info,
+            display: Mutex::new(display),
+            owner_process: AtomicI64::new(-1),
+        }
+    }
+
+    pub fn lock_process(&self, pid: u64) -> Option<MutexGuard<VgaDisplay>> {
+        if self.owner_process.load(Ordering::Relaxed) == pid as i64 {
+            Some(self.display.lock())
+        } else {
+            None
+        }
+    }
+
+    pub fn lock_kernel(&self) -> Option<MutexGuard<VgaDisplay>> {
+        if self.owner_process.load(Ordering::Relaxed) == -1 {
+            Some(self.display.lock())
+        } else {
+            None
+        }
+    }
+
+    pub fn take_ownership(&self, pid: u64) -> bool {
+        assert!(pid < i64::MAX as u64);
+        self.owner_process
+            .compare_exchange(
+                -1,
+                pid as i64,
+                core::sync::atomic::Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    pub fn release(&self, pid: u64) -> bool {
+        assert!(pid < i64::MAX as u64);
+        self.owner_process
+            .compare_exchange(
+                pid as i64,
+                -1,
+                core::sync::atomic::Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    pub fn framebuffer_info(&self) -> &FrameBufferInfo {
+        &self.framebuffer_info
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FrameBufferInfo {
+    pub pitch: usize,
+    pub height: usize,
+    pub width: usize,
+    pub field_pos: (u8, u8, u8),
+    pub mask: (u8, u8, u8),
+    pub byte_per_pixel: u8,
+}
+
+impl FrameBufferInfo {
+    fn get_arr_pos(&self, pos: (usize, usize)) -> usize {
+        pos.0 * self.byte_per_pixel as usize + pos.1 * self.pitch
+    }
+
+    fn read_pixel(&self, memory: &[u8], pos: (usize, usize)) -> Pixel {
+        let i = self.get_arr_pos(pos);
+        let pixel_mem = &memory[i..i + self.byte_per_pixel as usize];
+        Pixel {
+            r: pixel_mem[self.field_pos.0 as usize],
+            g: pixel_mem[self.field_pos.1 as usize],
+            b: pixel_mem[self.field_pos.2 as usize],
+        }
+    }
+
+    fn write_pixel(&self, memory: &mut [u8], pos: (usize, usize), color: Pixel) {
+        let i = self.get_arr_pos(pos);
+        let pixel_mem = &mut memory[i..i + self.byte_per_pixel as usize];
+
+        let r = color.r & self.mask.0;
+        let g = color.g & self.mask.1;
+        let b = color.b & self.mask.2;
+        pixel_mem[self.field_pos.0 as usize] = r;
+        pixel_mem[self.field_pos.1 as usize] = g;
+        pixel_mem[self.field_pos.2 as usize] = b;
+    }
+}
+
+pub struct VgaDisplay {
+    fb_info: FrameBufferInfo,
+    memory: VirtualSpace<[u8]>,
+}
+
+#[allow(dead_code)]
+impl VgaDisplay {
+    fn new(framebuffer: multiboot2::Framebuffer) -> Self {
+        let multiboot2::FramebufferColorInfo::Rgb {
+            red_field_position,
+            red_mask_size,
+            green_field_position,
+            green_mask_size,
+            blue_field_position,
+            blue_mask_size,
+        } = framebuffer.color_info
+        else {
+            panic!("Only RGB framebuffer is supported");
+        };
+        assert!(
+            framebuffer.bpp % 8 == 0,
+            "Only byte aligned bpp is supported"
+        );
+        assert!(
+            red_field_position % 8 == 0
+                && green_field_position % 8 == 0
+                && blue_field_position % 8 == 0,
+            "Only byte aligned field position is supported"
+        );
+
+        let physical_addr = framebuffer.addr;
+        let memory_size = framebuffer.pitch * framebuffer.height;
+        let memory =
+            unsafe { VirtualSpace::new_slice(physical_addr, memory_size as usize).unwrap() };
+
+        let red_mask = (1 << red_mask_size) - 1;
+        let green_mask = (1 << green_mask_size) - 1;
+        let blue_mask = (1 << blue_mask_size) - 1;
+        Self {
+            fb_info: FrameBufferInfo {
+                pitch: framebuffer.pitch as usize,
+                height: framebuffer.height as usize,
+                width: framebuffer.width as usize,
+                field_pos: (
+                    red_field_position / 8,
+                    green_field_position / 8,
+                    blue_field_position / 8,
+                ),
+                mask: (red_mask as u8, green_mask as u8, blue_mask as u8),
+                byte_per_pixel: (framebuffer.bpp + 7) / 8,
+            },
+            memory,
+        }
+    }
+
+    pub fn put_pixel(&mut self, x: usize, y: usize, color: Pixel) {
+        self.fb_info.write_pixel(&mut self.memory, (x, y), color);
+    }
+
+    pub fn clear(&mut self) {
+        self.memory.fill(0);
+    }
+
+    pub fn blit_inner_ranges(
+        &mut self,
+        src: (usize, usize),
+        dest: (usize, usize),
+        width: usize,
+        height: usize,
+    ) {
+        let (src_x, src_y) = src;
+        let (dest_x, dest_y) = dest;
+        assert!(src_x + width <= self.fb_info.width);
+        assert!(src_y + height <= self.fb_info.height);
+        assert!(dest_x + width <= self.fb_info.width);
+        assert!(dest_y + height <= self.fb_info.height);
+
+        // assert no overlap
+        assert!(
+            (src_x + width <= dest_x
+                || dest_x + width <= src_x
+                || src_y + height <= dest_y
+                || dest_y + height <= src_y)
+        );
+
+        let chunk_size = width * self.fb_info.byte_per_pixel as usize;
+
+        // Some optimization to avoid checking the condition for each pixel
+        // we create a closure that will be called for each line
+        let is_src_after =
+            src_y * self.fb_info.pitch + src_x > dest_y * self.fb_info.pitch + dest_x;
+        let mut copy_handler_src_after;
+        let mut copy_handler_src_before;
+        let copy_handler: &mut dyn FnMut(usize, usize, &mut [u8]) = if is_src_after {
+            copy_handler_src_after = |src_i: usize, dest_i: usize, memory: &mut [u8]| {
+                let (before, after) = memory.split_at_mut(src_i);
+                before[dest_i..dest_i + chunk_size].copy_from_slice(&after[..chunk_size]);
+            };
+            &mut copy_handler_src_after
+        } else {
+            copy_handler_src_before = |src_i: usize, dest_i: usize, memory: &mut [u8]| {
+                let (before, after) = memory.split_at_mut(src_i);
+                before[dest_i..dest_i + chunk_size].copy_from_slice(&after[..chunk_size]);
+            };
+            &mut copy_handler_src_before
+        };
+
+        for y in 0..height {
+            let src_i = self.fb_info.get_arr_pos((src_x, src_y + y));
+            let dest_i = self.fb_info.get_arr_pos((dest_x, dest_y + y));
+
+            copy_handler(src_i, dest_i, &mut self.memory);
+        }
+    }
+
+    pub fn blit(
+        &mut self,
+        src_buffer: &[u8],
+        src_framebuffer_info: &FrameBufferInfo,
+        src: (usize, usize),
+        dest: (usize, usize),
+        width: usize,
+        height: usize,
+    ) {
+        if self.fb_info.byte_per_pixel == src_framebuffer_info.byte_per_pixel
+            && self.fb_info.field_pos == src_framebuffer_info.field_pos
+            && self.fb_info.mask == src_framebuffer_info.mask
+        {
+            // Safety: we know this can work because we have the same format
+            unsafe { self.blit_fast(src_buffer, src_framebuffer_info, src, dest, width, height) }
+        } else {
+            self.blit_slow(src_buffer, src_framebuffer_info, src, dest, width, height)
+        }
+    }
+
+    /// blit the src framebuffer to the current framebuffer
+    /// `fast` here means that we assume the src and dest have the same format
+    unsafe fn blit_fast(
+        &mut self,
+        src_buffer: &[u8],
+        src_framebuffer_info: &FrameBufferInfo,
+        src: (usize, usize),
+        dest: (usize, usize),
+        width: usize,
+        height: usize,
+    ) {
+        let (src_x, src_y) = src;
+        let (dest_x, dest_y) = dest;
+        assert!(src_x + width <= src_framebuffer_info.width);
+        assert!(src_y + height <= src_framebuffer_info.height);
+        assert!(dest_x + width <= self.fb_info.width);
+        assert!(dest_y + height <= self.fb_info.height);
+
+        // assume same chunk size
+        let chunk_size = width * self.fb_info.byte_per_pixel as usize;
+
+        for y in 0..height {
+            let src_i = src_framebuffer_info.get_arr_pos((src_x, src_y + y));
+            let dest_i = self.fb_info.get_arr_pos((dest_x, dest_y + y));
+
+            let src_line = &src_buffer[src_i..src_i + chunk_size];
+            let dest_line = &mut self.memory[dest_i..dest_i + chunk_size];
+            dest_line.copy_from_slice(src_line);
+        }
+    }
+
+    fn blit_slow(
+        &mut self,
+        src_buffer: &[u8],
+        src_framebuffer_info: &FrameBufferInfo,
+        src: (usize, usize),
+        dest: (usize, usize),
+        width: usize,
+        height: usize,
+    ) {
+        let (src_x, src_y) = src;
+        let (dest_x, dest_y) = dest;
+
+        assert!(dest_x + width <= self.fb_info.width);
+        assert!(dest_y + height <= self.fb_info.height);
+        assert!(src_x + width <= src_framebuffer_info.width);
+        assert!(src_y + height <= src_framebuffer_info.height);
+
+        for y in 0..height {
+            for x in 0..width {
+                let src_pixel = src_framebuffer_info.read_pixel(src_buffer, (src_x + x, src_y + y));
+                self.fb_info
+                    .write_pixel(&mut self.memory, (dest_x + x, dest_y + y), src_pixel);
+            }
+        }
+    }
+
+    pub fn clear_rect(
+        &mut self,
+        dest_x: usize,
+        dest_y: usize,
+        width: usize,
+        height: usize,
+        color: Pixel,
+    ) {
+        assert!(dest_x + width <= self.fb_info.width);
+        assert!(dest_y + height <= self.fb_info.height);
+
+        if height == 0 || width == 0 {
+            return;
+        }
+
+        let line_chunk_size = width * self.fb_info.byte_per_pixel as usize;
+        let first_line_start = self.fb_info.get_arr_pos((dest_x, dest_y));
+        let first_line_end = first_line_start + line_chunk_size;
+        let first_line = &mut self.memory[first_line_start..first_line_end];
+
+        // fill the first line
+        for i in 0..width {
+            self.fb_info.write_pixel(first_line, (i, 0), color);
+        }
+
+        // take from the end of the first line, i.e. `before` will have the first line
+        // and `after` will have the rest of the memory
+        let second_line_start = self.fb_info.get_arr_pos((0, dest_y + 1));
+        let (before, after) = self.memory.split_at_mut(second_line_start);
+        let first_line = &before[first_line_start..first_line_end];
+
+        for y in 1..height {
+            let dest_i = self.fb_info.get_arr_pos((dest_x, y - 1));
+            let dest_line = &mut after[dest_i..dest_i + line_chunk_size];
+            dest_line.copy_from_slice(first_line);
+        }
+    }
+}
+
+impl DrawTarget for VgaDisplay {
+    type Color = Rgb888;
+
+    type Error = ();
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = embedded_graphics::prelude::Pixel<Self::Color>>,
+    {
+        for embedded_graphics::prelude::Pixel(pos, color) in pixels {
+            self.put_pixel(pos.x as usize, pos.y as usize, color.into());
+        }
+        Ok(())
+    }
+
+    fn fill_solid(
+        &mut self,
+        area: &embedded_graphics::primitives::Rectangle,
+        color: Self::Color,
+    ) -> Result<(), Self::Error> {
+        let (x, y) = (area.top_left.x as usize, area.top_left.y as usize);
+        let (width, height) = (area.size.width as usize, area.size.height as usize);
+        self.clear_rect(x, y, width, height, color.into());
+
+        Ok(())
+    }
+
+    fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+        self.clear_rect(0, 0, self.fb_info.width, self.fb_info.height, color.into());
+        Ok(())
+    }
+}
+
+impl OriginDimensions for VgaDisplay {
+    fn size(&self) -> geometry::Size {
+        geometry::Size::new(self.fb_info.width as u32, self.fb_info.height as u32)
+    }
+}

--- a/kernel/src/io/console.rs
+++ b/kernel/src/io/console.rs
@@ -62,7 +62,10 @@ fn create_video_console(framebuffer: Option<multiboot2::Framebuffer>) -> Box<dyn
     match framebuffer {
         Some(framebuffer) => match framebuffer.color_info {
             FramebufferColorInfo::Indexed { .. } => todo!(),
-            FramebufferColorInfo::Rgb { .. } => Box::new(VgaGraphics::new(framebuffer)),
+            FramebufferColorInfo::Rgb { .. } => {
+                // assumes we have already initialized the vga display
+                Box::new(VgaGraphics::new())
+            }
             FramebufferColorInfo::EgaText => Box::new(VgaText::new(framebuffer)),
         },
         None => panic!("No framebuffer provided"),

--- a/kernel/src/io/console/vga_graphics.rs
+++ b/kernel/src/io/console/vga_graphics.rs
@@ -1,6 +1,5 @@
 use embedded_graphics::{
-    draw_target::DrawTarget,
-    geometry::{OriginDimensions, Point},
+    geometry::Point,
     mono_font::{
         ascii::{FONT_9X15, FONT_9X15_BOLD},
         MonoTextStyle,
@@ -10,149 +9,79 @@ use embedded_graphics::{
         renderer::{CharacterStyle, TextRenderer},
         Baseline,
     },
-    Pixel,
 };
 
-use crate::{memory_management::virtual_space::VirtualSpace, multiboot2};
+use crate::graphics::{self, vga, Pixel};
 
 use super::{VideoConsole, VideoConsoleAttribute};
 
 pub(super) struct VgaGraphics {
-    pitch: usize,
-    height: usize,
-    width: usize,
-    field_pos: (u8, u8, u8),
-    mask: (u8, u8, u8),
-    byte_per_pixel: u8,
-    memory: VirtualSpace<[u8]>,
-
     pos: Point,
     text_style: MonoTextStyle<'static, Rgb888>,
+    vga: &'static vga::VgaDisplayController,
 }
 
 impl VgaGraphics {
-    pub fn new(framebuffer: multiboot2::Framebuffer) -> Self {
-        let multiboot2::FramebufferColorInfo::Rgb {
-            red_field_position,
-            red_mask_size,
-            green_field_position,
-            green_mask_size,
-            blue_field_position,
-            blue_mask_size,
-        } = framebuffer.color_info
-        else {
-            panic!("Only RGB framebuffer is supported");
-        };
-
-        let physical_addr = framebuffer.addr;
-        let memory_size = framebuffer.pitch * framebuffer.height;
-        let memory =
-            unsafe { VirtualSpace::new_slice(physical_addr, memory_size as usize).unwrap() };
-
-        let red_mask = (1 << red_mask_size) - 1;
-        let green_mask = (1 << green_mask_size) - 1;
-        let blue_mask = (1 << blue_mask_size) - 1;
+    pub fn new() -> Self {
         Self {
-            pitch: framebuffer.pitch as usize,
-            height: framebuffer.height as usize,
-            width: framebuffer.width as usize,
-            field_pos: (
-                red_field_position as u8 / 8,
-                green_field_position as u8 / 8,
-                blue_field_position as u8 / 8,
-            ),
-            mask: (red_mask as u8, green_mask as u8, blue_mask as u8),
-            byte_per_pixel: (framebuffer.bpp + 7) / 8,
-            memory,
             pos: Point::new(0, 0),
             text_style: MonoTextStyle::new(&FONT_9X15, Rgb888::WHITE),
+            vga: graphics::vga::controller().expect("We should have a VGA controller by now!"),
         }
     }
 
-    fn get_arr_pos(&self, pos: (usize, usize)) -> usize {
-        pos.0 * self.byte_per_pixel as usize + pos.1 * self.pitch
+    pub fn clear_current_text_line(&mut self, vga: &mut vga::VgaDisplay) {
+        let fb_info = self.vga.framebuffer_info();
+        vga.clear_rect(
+            0,
+            self.pos.y as usize,
+            fb_info.width,
+            self.text_style.line_height() as usize,
+            Pixel { r: 0, g: 0, b: 0 },
+        );
     }
 
-    pub fn put_pixel(&mut self, x: usize, y: usize, color: Rgb888) {
-        let i = self.get_arr_pos((x, y));
-        let pixel_mem = &mut self.memory[i..i + self.byte_per_pixel as usize];
-
-        let r = color.r() & self.mask.0;
-        let g = color.g() & self.mask.1;
-        let b = color.b() & self.mask.2;
-        pixel_mem[self.field_pos.0 as usize] = r;
-        pixel_mem[self.field_pos.1 as usize] = g;
-        pixel_mem[self.field_pos.2 as usize] = b;
-    }
-
-    pub fn clear(&mut self) {
-        self.memory.fill(0);
-    }
-
-    pub fn clear_current_text_line(&mut self) {
-        let start = self.get_arr_pos((0, self.pos.y as usize));
-        let line_chunk_size = self.pitch * self.text_style.line_height() as usize;
-        self.memory[start..start + line_chunk_size].fill(0);
-    }
-
-    fn scroll(&mut self, lines: usize) {
-        let chunk_size = self.pitch * lines;
-
+    fn scroll(&mut self, lines: usize, vga: &mut vga::VgaDisplay) {
+        let fb_info = self.vga.framebuffer_info();
+        let height = fb_info.height;
+        let width = fb_info.width;
         let mut i = 0;
-        while i < self.height - lines * 2 {
-            // copy chunks of height (lines) each time
-            let copy_to_start = self.get_arr_pos((0, i));
-            let copy_from_start = self.get_arr_pos((0, i + lines));
-            let (before, after) = self.memory.split_at_mut(copy_from_start);
+        while i < height - lines * 2 {
+            vga.blit_inner_ranges((0, i + lines), (0, i), width, lines);
 
-            before[copy_to_start..copy_to_start + chunk_size].copy_from_slice(&after[..chunk_size]);
             i += lines;
         }
         self.pos.y -= lines as i32;
     }
 
     fn fix_after_advance(&mut self) {
-        if self.pos.x >= self.width as i32 {
+        let fb_info = self.vga.framebuffer_info();
+        let width = fb_info.width as i32;
+        let height = fb_info.height as i32;
+        if self.pos.x >= width {
             self.pos.x = 0;
             self.pos.y += self.text_style.line_height() as i32;
         }
-        if self.pos.y + self.text_style.line_height() as i32 >= self.height as i32 {
-            // scroll up
-            self.scroll(self.text_style.line_height() as usize);
+        if self.pos.y + self.text_style.line_height() as i32 >= height {
+            if let Some(mut vga) = self.vga.lock_kernel() {
+                // scroll up
+                self.scroll(self.text_style.line_height() as usize, &mut vga);
 
-            // clear line
-            self.clear_current_text_line();
+                // clear line
+                self.clear_current_text_line(&mut vga);
+            }
+
             // just to make sure we are not out of bounds by more than 1 line
             self.fix_after_advance();
         }
     }
 }
 
-impl DrawTarget for VgaGraphics {
-    type Color = Rgb888;
-
-    type Error = ();
-
-    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
-    where
-        I: IntoIterator<Item = embedded_graphics::prelude::Pixel<Self::Color>>,
-    {
-        for Pixel(pos, color) in pixels {
-            self.put_pixel(pos.x as usize, pos.y as usize, color);
-        }
-        Ok(())
-    }
-}
-
-impl OriginDimensions for VgaGraphics {
-    fn size(&self) -> embedded_graphics::geometry::Size {
-        embedded_graphics::geometry::Size::new(self.width as u32, self.height as u32)
-    }
-}
-
 impl VideoConsole for VgaGraphics {
     fn init(&mut self) {
-        self.clear();
+        if let Some(mut vga) = self.vga.lock_kernel() {
+            vga.clear();
+        }
     }
 
     fn write_byte(&mut self, c: u8) {
@@ -164,9 +93,14 @@ impl VideoConsole for VgaGraphics {
 
             let style = self.text_style;
 
-            self.pos = style
-                .draw_string(str, self.pos, Baseline::Bottom, self)
-                .unwrap();
+            if let Some(mut vga) = self.vga.lock_kernel() {
+                self.pos = style
+                    .draw_string(str, self.pos, Baseline::Bottom, &mut *vga)
+                    .unwrap();
+            } else {
+                // nothing changed, so no need to check for scroll
+                return;
+            }
         }
         self.fix_after_advance();
     }

--- a/kernel/src/io/console/vga_graphics.rs
+++ b/kernel/src/io/console/vga_graphics.rs
@@ -58,7 +58,7 @@ impl VgaGraphics {
         let fb_info = self.vga.framebuffer_info();
         let width = fb_info.width as i32;
         let height = fb_info.height as i32;
-        if self.pos.x >= width {
+        if self.pos.x + self.text_style.font.character_size.width as i32 >= width {
             self.pos.x = 0;
             self.pos.y += self.text_style.line_height() as i32;
         }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -19,10 +19,11 @@ mod cpu;
 mod devices;
 mod executable;
 mod fs;
+mod graphics;
 mod io;
 mod memory_management;
 mod multiboot2;
-pub mod process;
+mod process;
 mod sync;
 
 use core::hint;
@@ -134,6 +135,7 @@ pub extern "C" fn kernel_main(multiboot_info: &MultiBoot2Info) -> ! {
     // and interrupts should be disabled until
     unsafe { cpu::set_interrupts() };
     devices::init_legacy_devices();
+    graphics::vga::init(multiboot_info.framebuffer());
     console::init_late_device(multiboot_info.framebuffer());
     devices::prope_pci_devices();
     fs::create_disk_mapping(0).expect("Could not load filesystem");

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     devices::clock::ClockTime,
     executable::{elf, load_elf_to_vm},
     fs,
+    graphics::vga,
     memory_management::{
         memory_layout::{align_down, align_up, is_aligned, GB, KERNEL_BASE, MB, PAGE_2M, PAGE_4K},
         virtual_memory_mapper::{
@@ -278,6 +279,10 @@ impl Process {
     pub fn exit(&mut self, exit_code: i32) {
         self.state = ProcessState::Exited;
         self.exit_code = exit_code;
+        // release the vga if we have it
+        if let Some(vga) = vga::controller() {
+            vga.release(self.id);
+        }
     }
 
     pub fn add_child_exit(&mut self, pid: u64, exit_code: i32) {

--- a/kernel/src/sync/spin/remutex.rs
+++ b/kernel/src/sync/spin/remutex.rs
@@ -57,7 +57,6 @@ where
     }
 }
 
-#[allow(dead_code)]
 impl<T> ReMutex<T> {
     pub const fn new(data: T) -> Self {
         Self {
@@ -125,6 +124,10 @@ impl<T> ReMutex<T> {
         } else {
             None
         }
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.data
     }
 }
 

--- a/libraries/emerald_std/Cargo.toml
+++ b/libraries/emerald_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_std"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]
@@ -14,7 +14,7 @@ categories = ["os"]
 
 [dependencies]
 increasing_heap_allocator = { version="0.1.3", path = "../increasing_heap_allocator" }
-kernel_user_link = { version="0.2.3", path = "../kernel_user_link", package = "emerald_kernel_user_link" }
+kernel_user_link = { version="0.2.4", path = "../kernel_user_link", package = "emerald_kernel_user_link" }
 
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }

--- a/libraries/emerald_std/src/graphics.rs
+++ b/libraries/emerald_std/src/graphics.rs
@@ -1,0 +1,96 @@
+use core::mem::MaybeUninit;
+
+pub use kernel_user_link::graphics::{FrameBufferInfo, GraphicsCommand};
+use kernel_user_link::{
+    call_syscall,
+    syscalls::{SyscallError, SYS_GRAPHICS},
+};
+
+pub struct BlitCommand<'a> {
+    pub memory: &'a [u8],
+    pub src_framebuffer_info: FrameBufferInfo,
+    pub src: (usize, usize),
+    pub dst: (usize, usize),
+    pub size: (usize, usize),
+}
+
+impl BlitCommand<'_> {
+    fn is_buffer_valid(&self) -> bool {
+        // check the memory buffer
+        let buf_expected_len = self.src_framebuffer_info.memory_size();
+        if self.memory.len() != buf_expected_len {
+            return false;
+        }
+
+        // check the `src`
+        if self.src.0 >= self.src_framebuffer_info.width
+            || self.src.1 >= self.src_framebuffer_info.height
+            || self.src.0 + self.size.0 > self.src_framebuffer_info.width
+            || self.src.1 + self.size.1 > self.src_framebuffer_info.height
+        {
+            return false;
+        }
+
+        // the `dst` relies on the framebuffer info of the kernel
+        // we don't have that info here, so we can't check it
+        true
+    }
+}
+
+/// # Safety
+/// This function assumes that `command` and `extra` are valid.
+/// based on what's expected by the kernel.
+unsafe fn graphics(command: GraphicsCommand, extra: u64) -> Result<(), SyscallError> {
+    unsafe {
+        call_syscall!(
+            SYS_GRAPHICS,
+            command as u64, // command
+            extra,          // extra
+        )
+        .map(|e| assert!(e == 0))
+    }
+}
+
+pub fn take_ownership() -> Result<(), SyscallError> {
+    // Safety: `TakeOwnership` is a valid command, and doesn't require any extra data.
+    unsafe { graphics(GraphicsCommand::TakeOwnership, 0) }
+}
+
+pub fn release_ownership() -> Result<(), SyscallError> {
+    // Safety: `ReleaseOwnership` is a valid command, and doesn't require any extra data.
+    unsafe { graphics(GraphicsCommand::ReleaseOwnership, 0) }
+}
+
+pub fn get_framebuffer_info() -> Result<FrameBufferInfo, SyscallError> {
+    let mut info = MaybeUninit::<FrameBufferInfo>::uninit();
+
+    // Safety: `GetFrameBufferInfo` is a valid command, and requires a valid `FrameBufferInfo` pointer.
+    //         which rust guarantees here.
+    unsafe {
+        graphics(
+            GraphicsCommand::GetFrameBufferInfo,
+            info.as_mut_ptr() as *const _ as u64,
+        )?;
+    }
+
+    // Safety: `info` is now initialized.
+    unsafe { Ok(info.assume_init()) }
+}
+
+pub fn blit(command: &BlitCommand) -> Result<(), SyscallError> {
+    if !command.is_buffer_valid() {
+        return Err(SyscallError::InvalidGraphicsBuffer);
+    }
+
+    let converted_command = kernel_user_link::graphics::BlitCommand {
+        memory: command.memory.as_ptr(),
+        src_framebuffer_info: command.src_framebuffer_info,
+        src: command.src,
+        dst: command.dst,
+        size: command.size,
+    };
+
+    // Safety: `Blit` is a valid command, and requires a valid `BlitCommand` pointer.
+    //         we just created one right now, so its valid.
+    unsafe { graphics(GraphicsCommand::Blit, &converted_command as *const _ as u64) }
+}

--- a/libraries/emerald_std/src/lib.rs
+++ b/libraries/emerald_std/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod alloc;
 pub mod clock;
+pub mod graphics;
 pub mod io;
 pub mod process;
 mod sync;

--- a/libraries/kernel_user_link/Cargo.toml
+++ b/libraries/kernel_user_link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_kernel_user_link"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]

--- a/libraries/kernel_user_link/src/graphics.rs
+++ b/libraries/kernel_user_link/src/graphics.rs
@@ -1,0 +1,95 @@
+#[repr(u64)]
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum GraphicsCommand {
+    /// Take ownership of the graphics device
+    /// No arguments
+    TakeOwnership,
+    /// Release ownership of the graphics device
+    /// No arguments
+    ReleaseOwnership,
+    /// Get information about the framebuffer
+    /// &mut FrameBufferInfo
+    GetFrameBufferInfo,
+    /// Blit a region from userspace memory into the graphics framebuffer
+    /// (must have ownership of the graphics device)
+    /// &BlitCommand
+    Blit,
+}
+
+impl GraphicsCommand {
+    pub fn from_u64(value: u64) -> Option<Self> {
+        match value {
+            0 => Some(Self::TakeOwnership),
+            1 => Some(Self::ReleaseOwnership),
+            2 => Some(Self::GetFrameBufferInfo),
+            3 => Some(Self::Blit),
+            _ => None,
+        }
+    }
+
+    pub fn to_u64(self) -> u64 {
+        self as u64
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FrameBufferInfo {
+    pub pitch: usize,
+    pub height: usize,
+    pub width: usize,
+    pub field_pos: (u8, u8, u8),
+    pub mask: (u8, u8, u8),
+    pub byte_per_pixel: u8,
+}
+
+impl FrameBufferInfo {
+    /// The size of the memory buffer required to hold the framebuffer
+    pub fn memory_size(&self) -> usize {
+        self.pitch * self.height
+    }
+
+    /// Get the position in the memory buffer for a given pixel
+    /// Returns None if the position is out of bounds
+    pub fn get_arr_pos(&self, pos: (usize, usize)) -> Option<usize> {
+        if pos.0 >= self.width || pos.1 >= self.height {
+            return None;
+        }
+        Some(pos.0 * self.byte_per_pixel as usize + pos.1 * self.pitch)
+    }
+
+    /// Get the pixel slice at a given position (read-only)
+    pub fn pixel_mem<'a>(&self, memory: &'a [u8], pos: (usize, usize)) -> Option<&'a [u8]> {
+        let i = self.get_arr_pos(pos)?;
+        Some(&memory[i..i + self.byte_per_pixel as usize])
+    }
+
+    /// Get the pixel slice at a given position
+    pub fn pixel_mem_mut<'a>(
+        &self,
+        memory: &'a mut [u8],
+        pos: (usize, usize),
+    ) -> Option<&'a mut [u8]> {
+        let i = self.get_arr_pos(pos)?;
+        Some(&mut memory[i..i + self.byte_per_pixel as usize])
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct BlitCommand {
+    /// The memory buffer to blit from, this represent the whole framebuffer
+    /// even if we are only blitting a part of it
+    pub memory: *const u8,
+    /// The framebuffer info of the source memory
+    /// i.e. metadata about `memory`
+    pub src_framebuffer_info: FrameBufferInfo,
+    /// The position in the source framebuffer to start blitting from
+    pub src: (usize, usize),
+    /// The position in the destination framebuffer to start blitting to
+    /// this destination is the kernel's framebuffer
+    pub dst: (usize, usize),
+    /// The size of the region to blit (width, height)
+    pub size: (usize, usize),
+}

--- a/libraries/kernel_user_link/src/lib.rs
+++ b/libraries/kernel_user_link/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod clock;
 pub mod file;
+pub mod graphics;
 pub mod process;
 pub mod syscalls;
 

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -6,7 +6,7 @@ mod types_conversions;
 /// user-kernel
 pub const SYSCALL_INTERRUPT_NUMBER: u8 = 0xFE;
 
-pub const NUM_SYSCALLS: usize = 19;
+pub const NUM_SYSCALLS: usize = 20;
 
 mod numbers {
     pub const SYS_OPEN: u64 = 0;
@@ -29,6 +29,7 @@ mod numbers {
     pub const SYS_GET_FILE_META: u64 = 16;
     pub const SYS_SLEEP: u64 = 17;
     pub const SYS_GET_TIME: u64 = 18;
+    pub const SYS_GRAPHICS: u64 = 19;
 }
 pub use numbers::*;
 
@@ -242,6 +243,10 @@ pub enum SyscallError {
     IsNotDirectory = 13,
     IsDirectory = 14,
     BufferTooSmall = 15,
+    GraphicsNotAvailable = 16,
+    GraphicsAlreadyTaken = 17,
+    GraphicsNotOwned = 18,
+    InvalidGraphicsBuffer = 19,
     InvalidArgument(
         Option<SyscallArgError>,
         Option<SyscallArgError>,
@@ -330,6 +335,10 @@ pub fn syscall_result_to_u64(result: SyscallResult) -> u64 {
                 SyscallError::IsNotDirectory => 13 << 56,
                 SyscallError::IsDirectory => 14 << 56,
                 SyscallError::BufferTooSmall => 15 << 56,
+                SyscallError::GraphicsNotAvailable => 16 << 56,
+                SyscallError::GraphicsAlreadyTaken => 17 << 56,
+                SyscallError::GraphicsNotOwned => 18 << 56,
+                SyscallError::InvalidGraphicsBuffer => 19 << 56,
                 SyscallError::InvalidError => panic!("Should never be used"),
             };
 
@@ -383,6 +392,10 @@ pub fn syscall_result_from_u64(value: u64) -> SyscallResult {
             13 => SyscallError::IsNotDirectory,
             14 => SyscallError::IsDirectory,
             15 => SyscallError::BufferTooSmall,
+            16 => SyscallError::GraphicsNotAvailable,
+            17 => SyscallError::GraphicsAlreadyTaken,
+            18 => SyscallError::GraphicsNotOwned,
+            19 => SyscallError::InvalidGraphicsBuffer,
             _ => SyscallError::InvalidError,
         };
         SyscallResult::Err(err)

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -2,8 +2,10 @@
 RUSTC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2/bin/rustc"
 RUSTDOC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2/rustdoc"
 USER_OUTDIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/x86_64-unknown-emerald/${PROFILE}"
+CARGO_MAKE_CARGO_PROFILE = { source = "${PROFILE}", default_value = "debug", mapping = {"debug" = "dev", "release" = "release" } }
 
-CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = ["init", "shell"]
+
+CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = ["init", "shell", "graphics"]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 CARGO_MAKE_WORKSPACE_EMULATION = true
 # BUG in cargo-make, it uses `cargo` to get metadata about `rustc`, and it uses the system toolchain
@@ -41,4 +43,4 @@ workspace = false
 dependencies = ["build_member"]
 condition= {files_modified = {input=["${USER_OUTDIR}/${CARGO_MAKE_PROJECT_NAME}"], output=["${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]}}
 command = "cp"
-args = ["-r", "${USER_OUTDIR}/echo", "${USER_OUTDIR}/cat", "${USER_OUTDIR}/ls", "${USER_OUTDIR}/xxd", "${FILESYSTEM_PATH}/"]
+args = ["-r", "${USER_OUTDIR}/echo", "${USER_OUTDIR}/cat", "${USER_OUTDIR}/ls", "${USER_OUTDIR}/xxd", "${USER_OUTDIR}/graphics", "${FILESYSTEM_PATH}/"]

--- a/userspace/graphics/Cargo.toml
+++ b/userspace/graphics/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "graphics"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+emerald_std = { version = "0.2.6", path = "../../libraries/emerald_std" }
+embedded-graphics = "0.8"

--- a/userspace/graphics/src/main.rs
+++ b/userspace/graphics/src/main.rs
@@ -1,0 +1,236 @@
+//! This is a demo of using the graphics API to draw a bouncing circle and text on the screen.
+
+use std::thread::sleep;
+
+use embedded_graphics::{
+    draw_target::DrawTarget,
+    geometry::{Dimensions, OriginDimensions, Point},
+    mono_font::{ascii::FONT_9X15, MonoTextStyle},
+    pixelcolor::{Rgb888, RgbColor},
+    primitives::{Circle, Primitive, PrimitiveStyle},
+    text::{Baseline, Text},
+    transform::Transform,
+    Drawable,
+};
+use emerald_std::graphics::{BlitCommand, FrameBufferInfo};
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pixel {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl<T: RgbColor> From<T> for Pixel {
+    fn from(color: T) -> Self {
+        Self {
+            r: color.r(),
+            g: color.g(),
+            b: color.b(),
+        }
+    }
+}
+
+struct Graphics {
+    framebuffer: Box<[u8]>,
+    framebuffer_info: FrameBufferInfo,
+}
+
+impl Graphics {
+    pub fn new() -> Self {
+        emerald_std::graphics::take_ownership().unwrap();
+        let info = emerald_std::graphics::get_framebuffer_info().unwrap();
+        let memory = vec![0; info.memory_size()].into_boxed_slice();
+
+        Self {
+            framebuffer: memory,
+            framebuffer_info: info,
+        }
+    }
+
+    fn write_pixel(&mut self, pos: (usize, usize), color: Pixel) -> Option<()> {
+        let pixel_mem = self
+            .framebuffer_info
+            .pixel_mem_mut(&mut self.framebuffer, pos)?;
+        let r = color.r & self.framebuffer_info.mask.0;
+        let g = color.g & self.framebuffer_info.mask.1;
+        let b = color.b & self.framebuffer_info.mask.2;
+        pixel_mem[self.framebuffer_info.field_pos.0 as usize] = r;
+        pixel_mem[self.framebuffer_info.field_pos.1 as usize] = g;
+        pixel_mem[self.framebuffer_info.field_pos.2 as usize] = b;
+
+        Some(())
+    }
+
+    pub fn clear_rect(
+        &mut self,
+        dest_x: usize,
+        dest_y: usize,
+        width: usize,
+        height: usize,
+        color: Pixel,
+    ) -> Option<()> {
+        if dest_x + width > self.framebuffer_info.width
+            || dest_y + height > self.framebuffer_info.height
+        {
+            return None;
+        }
+
+        if height == 0 || width == 0 {
+            return Some(());
+        }
+
+        let line_chunk_size = width * self.framebuffer_info.byte_per_pixel as usize;
+        let first_line_start = self.framebuffer_info.get_arr_pos((dest_x, dest_y)).unwrap();
+        let first_line_end = first_line_start + line_chunk_size;
+
+        // fill the first line
+        for i in 0..width {
+            self.write_pixel((dest_x + i, dest_y), color);
+        }
+
+        if height == 1 {
+            return Some(());
+        }
+
+        // take from the end of the first line, i.e. `before` will have the first line
+        // and `after` will have the rest of the memory
+        let second_line_start = self.framebuffer_info.get_arr_pos((0, dest_y + 1)).unwrap();
+        let (before, after) = self.framebuffer.split_at_mut(second_line_start);
+        let first_line = &before[first_line_start..first_line_end];
+
+        for y in 1..height {
+            let dest_i = self.framebuffer_info.get_arr_pos((dest_x, y - 1)).unwrap();
+            let dest_line = &mut after[dest_i..dest_i + line_chunk_size];
+            dest_line.copy_from_slice(first_line);
+        }
+        Some(())
+    }
+
+    pub fn present(&self) {
+        emerald_std::graphics::blit(&BlitCommand {
+            memory: &self.framebuffer,
+            src_framebuffer_info: self.framebuffer_info,
+            src: (0, 0),
+            dst: (0, 0),
+            size: (self.framebuffer_info.width, self.framebuffer_info.height),
+        })
+        .unwrap();
+    }
+}
+
+impl Drop for Graphics {
+    fn drop(&mut self) {
+        emerald_std::graphics::release_ownership().unwrap();
+    }
+}
+
+impl DrawTarget for Graphics {
+    type Color = Rgb888;
+
+    type Error = ();
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = embedded_graphics::prelude::Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            let pos = pixel.0;
+            let color = pixel.1.into();
+            self.write_pixel((pos.x as usize, pos.y as usize), color)
+                .ok_or(())?;
+        }
+        Ok(())
+    }
+
+    fn fill_solid(
+        &mut self,
+        area: &embedded_graphics::primitives::Rectangle,
+        color: Self::Color,
+    ) -> Result<(), Self::Error> {
+        if area.top_left.x < 0
+            || area.top_left.y < 0
+            || area.bottom_right().unwrap().x >= self.framebuffer_info.width as i32
+            || area.bottom_right().unwrap().y >= self.framebuffer_info.height as i32
+        {
+            return Err(());
+        }
+
+        let (x, y) = (area.top_left.x as usize, area.top_left.y as usize);
+        let (width, height) = (area.size.width as usize, area.size.height as usize);
+        self.clear_rect(x, y, width, height, color.into());
+
+        Ok(())
+    }
+
+    fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+        self.clear_rect(
+            0,
+            0,
+            self.framebuffer_info.width,
+            self.framebuffer_info.height,
+            color.into(),
+        );
+        Ok(())
+    }
+}
+
+impl OriginDimensions for Graphics {
+    fn size(&self) -> embedded_graphics::geometry::Size {
+        embedded_graphics::geometry::Size::new(
+            self.framebuffer_info.width as u32,
+            self.framebuffer_info.height as u32,
+        )
+    }
+}
+
+fn main() {
+    let mut graphics = Graphics::new();
+
+    let mut circle =
+        Circle::new(Point::new(64, 64), 64).into_styled(PrimitiveStyle::with_fill(Rgb888::RED));
+    let mut v = Point::new(10, 10);
+
+    // Create a new character style
+    let style = MonoTextStyle::new(&FONT_9X15, Rgb888::WHITE);
+    let mut fps_text = "FPS: 0".to_string();
+
+    loop {
+        let time = std::time::SystemTime::now();
+
+        graphics.clear(Rgb888::BLACK).unwrap();
+
+        // update
+        {
+            // move the circle
+            circle.translate_mut(v);
+
+            // bounce the circle
+            if circle.bounding_box().top_left.x < 0
+                || circle.bounding_box().bottom_right().unwrap().x >= graphics.size().width as i32
+            {
+                v.x = -v.x;
+            }
+            if circle.bounding_box().top_left.y < 0
+                || circle.bounding_box().bottom_right().unwrap().y >= graphics.size().height as i32
+            {
+                v.y = -v.y;
+            }
+        }
+        // render
+        {
+            circle.draw(&mut graphics).ok();
+            let text = Text::with_baseline(&fps_text, Point::new(0, 0), style, Baseline::Top);
+            text.draw(&mut graphics).ok();
+        }
+        graphics.present();
+        let remaining =
+            std::time::Duration::from_millis(1000 / 60).checked_sub(time.elapsed().unwrap());
+        if let Some(remaining) = remaining {
+            sleep(remaining);
+        }
+        let fps = 1.0 / time.elapsed().unwrap().as_secs_f64();
+        fps_text = format!("FPS: {:.2}", fps);
+    }
+}


### PR DESCRIPTION
## Summary

Added vga driver, and graphics controller.

With this, we can render anything from usermode.

The architecture is based on the kernel having direct access to the vga framebuffer, but a single process at a time
can gain exclusive access to the framebuffer and then can render anything into it using specific syscalls.

### Related issue

Fixes #63 


## Changes
- Added `vga` driver that renders images to the vga display.
- Added `graphics` syscalls api to allow rendering graphics from usermode.
    - `take/release ownership of the framebuffer`, a process to request ownership (if no other process has ownership), or release it when done (also released automatically on process exit)
    - `get framebuffer info`: Gets the shape of the vga framebuffer memory and its properties. As the userspace doesn't have direct access, so it must allocate memory, and its best to stay consistent with the memory shape on the kernel side for best performance
    - `blit image`, this is the only rendering function, all rendering should be handled by userspace and only the changed portions should be sent to the kernel, you can of course send the whole image, but its a bit slower this way, since we have to copy the  whole buffer.


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
