### PR TITLE
Math symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,11 +69,12 @@ dependencies = [
 
 [[package]]
 name = "emerald_std"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "compiler_builtins",
  "emerald_kernel_user_link",
  "increasing_heap_allocator",
+ "libm",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]
@@ -123,6 +124,15 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "git+https://github.com/Amjad50/libm?branch=compiling_libm_for_std#9ded10304060e82d5cb71fcf8ae99a9538802c65"
+dependencies = [
+ "compiler_builtins",
+ "rustc-std-workspace-core",
+]
 
 [[package]]
 name = "micromath"

--- a/libraries/emerald_std/Cargo.toml
+++ b/libraries/emerald_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_std"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]
@@ -15,6 +15,8 @@ categories = ["os"]
 [dependencies]
 increasing_heap_allocator = { version="0.1.3", path = "../increasing_heap_allocator" }
 kernel_user_link = { version="0.2.4", path = "../kernel_user_link", package = "emerald_kernel_user_link" }
+# for now, waiting for the PR https://github.com/rust-lang/libm/pull/290 to be merged
+libm = { version = "0.2.8", git = "https://github.com/Amjad50/libm", branch = "compiling_libm_for_std" }
 
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
@@ -27,5 +29,6 @@ rustc-dep-of-std = [
     "alloc",
     "compiler_builtins/mem",
     "kernel_user_link/rustc-dep-of-std",
-    "increasing_heap_allocator/rustc-dep-of-std"
+    "increasing_heap_allocator/rustc-dep-of-std",
+    "libm/rustc-dep-of-std"
 ]

--- a/libraries/emerald_std/src/graphics.rs
+++ b/libraries/emerald_std/src/graphics.rs
@@ -77,7 +77,7 @@ pub fn get_framebuffer_info() -> Result<FrameBufferInfo, SyscallError> {
     unsafe { Ok(info.assume_init()) }
 }
 
-pub fn blit(command: &BlitCommand) -> Result<(), SyscallError> {
+pub fn blit(command: &BlitCommand<'_>) -> Result<(), SyscallError> {
     if !command.is_buffer_valid() {
         return Err(SyscallError::InvalidGraphicsBuffer);
     }

--- a/libraries/emerald_std/src/lib.rs
+++ b/libraries/emerald_std/src/lib.rs
@@ -4,6 +4,7 @@ pub mod alloc;
 pub mod clock;
 pub mod graphics;
 pub mod io;
+pub mod math;
 pub mod process;
 mod sync;
 

--- a/libraries/emerald_std/src/lib.rs
+++ b/libraries/emerald_std/src/lib.rs
@@ -1,4 +1,9 @@
 #![no_std]
+// used to weak link libm functions
+// this is temporary, waiting for PRs to be merged
+// into `compiler-builtins`
+// https://github.com/rust-lang/compiler-builtins/pull/577
+#![feature(linkage)]
 
 pub mod alloc;
 pub mod clock;

--- a/libraries/emerald_std/src/math.rs
+++ b/libraries/emerald_std/src/math.rs
@@ -1,0 +1,2 @@
+//! Re-export of the `libm` crate.
+pub use libm::*;

--- a/libraries/emerald_std/src/math.rs
+++ b/libraries/emerald_std/src/math.rs
@@ -1,2 +1,99 @@
-//! Re-export of the `libm` crate.
-pub use libm::*;
+#[allow(unused_macros)]
+macro_rules! no_mangle {
+    ($(fn $fun:ident($($iid:ident : $ity:ty),+) -> $oty:ty;)+) => {
+        $(
+            #[linkage="weak"]
+            #[no_mangle]
+            pub unsafe extern "C" fn $fun($($iid: $ity),+) -> $oty {
+                libm::$fun($($iid),+)
+            }
+        )+
+    }
+}
+
+no_mangle! {
+    fn acos(n: f64) -> f64;
+    fn acosf(n: f32) -> f32;
+    fn asin(n: f64) -> f64;
+    fn asinf(n: f32) -> f32;
+    fn atan(n: f64) -> f64;
+    fn atan2(a: f64, b: f64) -> f64;
+    fn atan2f(a: f32, b: f32) -> f32;
+    fn atanf(n: f32) -> f32;
+    fn cbrt(n: f64) -> f64;
+    fn cbrtf(n: f32) -> f32;
+    fn cosh(n: f64) -> f64;
+    fn coshf(n: f32) -> f32;
+    fn expm1(n: f64) -> f64;
+    fn expm1f(n: f32) -> f32;
+    fn fdim(a: f64, b: f64) -> f64;
+    fn fdimf(a: f32, b: f32) -> f32;
+    fn hypot(x: f64, y: f64) -> f64;
+    fn hypotf(x: f32, y: f32) -> f32;
+    fn log1p(n: f64) -> f64;
+    fn log1pf(n: f32) -> f32;
+    fn sinh(n: f64) -> f64;
+    fn sinhf(n: f32) -> f32;
+    fn tan(n: f64) -> f64;
+    fn tanf(n: f32) -> f32;
+    fn tanh(n: f64) -> f64;
+    fn tanhf(n: f32) -> f32;
+    fn tgamma(n: f64) -> f64;
+    fn tgammaf(n: f32) -> f32;
+    // fn lgamma_r(n: f64, s: &mut i32) -> f64;
+    // fn lgammaf_r(n: f32, s: &mut i32) -> f32;
+    fn cos(x: f64) -> f64;
+    fn expf(x: f32) -> f32;
+    fn log2(x: f64) -> f64;
+    fn log2f(x: f32) -> f32;
+    fn log10(x: f64) -> f64;
+    fn log10f(x: f32) -> f32;
+    fn log(x: f64) -> f64;
+    fn logf(x: f32) -> f32;
+    fn fmin(x: f64, y: f64) -> f64;
+    fn fminf(x: f32, y: f32) -> f32;
+    fn fmax(x: f64, y: f64) -> f64;
+    fn fmaxf(x: f32, y: f32) -> f32;
+    fn round(x: f64) -> f64;
+    fn roundf(x: f32) -> f32;
+    fn rint(x: f64) -> f64;
+    fn rintf(x: f32) -> f32;
+    fn sin(x: f64) -> f64;
+    fn pow(x: f64, y: f64) -> f64;
+    fn powf(x: f32, y: f32) -> f32;
+    fn fmod(x: f64, y: f64) -> f64;
+    fn fmodf(x: f32, y: f32) -> f32;
+    fn ldexp(f: f64, n: i32) -> f64;
+    fn ldexpf(f: f32, n: i32) -> f32;
+    fn cosf(x: f32) -> f32;
+    fn exp(x: f64) -> f64;
+    fn sinf(x: f32) -> f32;
+    fn exp2(x: f64) -> f64;
+    fn exp2f(x: f32) -> f32;
+    fn fma(x: f64, y: f64, z: f64) -> f64;
+    fn fmaf(x: f32, y: f32, z: f32) -> f32;
+    fn sqrtf(x: f32) -> f32;
+    fn sqrt(x: f64) -> f64;
+    fn ceil(x: f64) -> f64;
+    fn ceilf(x: f32) -> f32;
+    fn floor(x: f64) -> f64;
+    fn floorf(x: f32) -> f32;
+    fn trunc(x: f64) -> f64;
+    fn truncf(x: f32) -> f32;
+}
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C" fn lgamma_r(x: f64, s: &mut i32) -> f64 {
+    let r = libm::lgamma_r(x);
+    *s = r.1;
+    r.0
+}
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C" fn lgammaf_r(x: f32, s: &mut i32) -> f32 {
+    let r = libm::lgammaf_r(x);
+    *s = r.1;
+    r.0
+}


### PR DESCRIPTION
## Summary
Linked missing math libraries manually for now until https://github.com/rust-lang/compiler-builtins/pull/577 is merged.

This fixes math symbols not found during linkage, as it relies on libc or other sources, that provide math functions from the OS (of course we don't have that)

### Related issue
None


## Changes
Added math libraries and linked it so that it can be included in `std`, since `std` uses `emerald_std` as a dep.


## Checklist
- [x] The changes are tested and works as expected (mention if not)
- [ ] Documentation
    - [x] not needed
- [ ] Needed README changes
    - [x] not needed
