### PR TITLE
Keyboard user driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,10 +24,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
+name = "blinkcast"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87be723831f9bfa47f0bc5b28edd97cbd8002726289d8bfd6dfdc1cd895e06d9"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "colored"
@@ -89,6 +119,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "graphics"
 version = "0.1.0"
 dependencies = [
@@ -113,6 +156,7 @@ version = "0.1.0"
 name = "kernel"
 version = "0.1.0"
 dependencies = [
+ "blinkcast",
  "byteorder",
  "embedded-graphics",
  "emerald_kernel_user_link",
@@ -126,6 +170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "git+https://github.com/Amjad50/libm?branch=compiling_libm_for_std#9ded10304060e82d5cb71fcf8ae99a9538802c65"
@@ -135,10 +185,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "loom"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e045d70ddfbc984eacfa964ded019534e8f6cbf36f6410aee0ed5cefa5a9175"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
 name = "micromath"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-traits"
@@ -148,6 +242,86 @@ checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustc-std-workspace-alloc"
@@ -162,10 +336,162 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1956f5517128a2b6f23ab2dadf1a976f4f5b27962e7724c2bf3d45e539ec098c"
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell"
 version = "0.1.0"
 dependencies = [
  "colored",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "syn"
+version = "2.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,10 +91,17 @@ dependencies = [
 
 [[package]]
 name = "emerald_kernel_user_link"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "emerald_keyboard"
+version = "0.1.0"
+dependencies = [
+ "emerald_kernel_user_link",
 ]
 
 [[package]]
@@ -361,6 +368,7 @@ name = "shell"
 version = "0.1.0"
 dependencies = [
  "colored",
+ "emerald_keyboard",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ default-members = ["kernel"]
 members = [
     "kernel",
     "libraries/kernel_user_link", "libraries/increasing_heap_allocator", "libraries/emerald_std",
-    "userspace/init", "userspace/shell", "userspace/graphics",
+    "libraries/keyboard",
+    "userspace/init", "userspace/shell", "userspace/graphics", 
 ]
 
 exclude = ["extern"]

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -15,6 +15,7 @@
     - [Virtual Devices](./kernel/virtual_devices/index.md)
         - [Console](./kernel/virtual_devices/console.md)
         - [Pipe](./kernel/virtual_devices/pipe.md)
+        - [Keyboard](./kernel/virtual_devices/keyboard.md)
     - [Filesystem](./kernel/filesystem/index.md)
         - [FAT](./kernel/filesystem/fat.md)
     - [Processor](./kernel/processor/index.md)

--- a/book/src/kernel/drivers/keyboard.md
+++ b/book/src/kernel/drivers/keyboard.md
@@ -6,18 +6,34 @@
 
 The keyboard driver is simple, and uses the legacy PS/2 interface at `0x60` and `0x64` ports.
 
-Currently we support the `US` layout only, but we have the return type from the device as 
+The driver provide events broadcasts to all listeners using [`blinkcast`]. These listeners
+are mostly processes reading from the `/devices/keyboard` file (see [keyboard virtual device](../virtual_devices/keyboard.md)).
 ```rust
 pub struct Key {
-    pub virtual_char: Option<u8>,
+    pub pressed: bool,
+    // the state of the modifiers at the time of the fetch
+    pub modifiers: u8,
     pub key_type: KeyType,
 }
 ```
 
-Where `KeyType` is an enum containing all keys, even not mapping to a character, like arrows, function keys, etc.
-Which we can use later to move mapping and other complex structures into the userspace.
+Where `KeyType` is an enum containing all keys from a US mapping.
 
-The keyboard provide [`get_next_char`][keyboard_get_next_char] which will keep up to last `8` characters in buffer.
-This is low level function, and will probably be read a lot from usermode, and `8` will probably be a lot of characters to keep in buffer, but lets see when the time comes.
+The keyboard user can then use this as the origin, and map it to any other key depending on the layout they want.
+
+Currently, we use the `US` layout to get the character of a key using the function [`Key::virtual_key`] (used in the kernel and userspace).
+
+The `modifiers` field is a bitflags from [`modifier`], so use these constants to check if a specific modifier is on.
+
+There are 2 types of modifiers:
+- Held modifiers: `SHIFT`, `CTRL`, `ALT`
+- Toggled modifiers: `CAPSLOCK`, `NUMLOCK`, `SCROLLLOCK`
+
+The keyboard driver provide a way to get a [`blinkcast`] reader using [`get_reader`][keyboard_get_reader], where the user can read
+keyboard events without blocking anytime they want.
 
 This is currently used by the [console](../virtual_devices/console.md) to read characters.
+
+[`blinkcast`]: https://crates.io/crates/blinkcast
+[`Key::virtual_key`]: https://docs.rs/emerald_kernel_user_link/0.2.5/emerald_kernel_user_link/keyboard/struct.Key.html#method.virtual_char
+[`modifier`]: https://docs.rs/emerald_kernel_user_link/0.2.5/emerald_kernel_user_link/keyboard/modifier

--- a/book/src/kernel/virtual_devices/keyboard.md
+++ b/book/src/kernel/virtual_devices/keyboard.md
@@ -1,0 +1,36 @@
+{{ #include ../../links.md }}
+
+# Keyboard
+
+> This is implemented in [`keyboard_device`][keyboard_device]
+
+Don't be confused with [keyboard driver](../drivers/keyboard.md), in there, we implement the hardware driver.
+
+This module is a client of that driver and provide user space access to the keyboard through the virtual device at `/devices/keyboard`.
+
+A process can open a file descriptor to this device and read from it to get keyboard events.
+
+The file descriptor will hold a [`blinkcast`] reader to the keyboard driver, then each process can read events without blocking.
+
+The user can open the file and read the content, but since we are performing some encoding, its better to use the library [`emerald_keyboard`] which provide easy way to read the events.
+
+Example:
+    
+```rust,no_run,no_compile
+use emerald_keyboard::Keyboard;
+
+let mut keyboard = Keyboard::new();
+
+if let Some(key) = keyboard.get_key_event() {
+    println!("Key: {:?}", key);
+}
+// or
+for key in keyboard.iter_keys() {
+    println!("Key: {:?}", key);
+}
+```
+
+[`blinkcast`]: https://crates.io/crates/blinkcast
+[`emerald_keyboard`]: https://crates.io/crates/emerald_keyboard
+
+

--- a/book/src/links.md.template
+++ b/book/src/links.md.template
@@ -8,7 +8,7 @@
 [ide_device]: {ROOT_PATH}docs/kernel/devices/ide
 [ide_read_sync]: {ROOT_PATH}docs/kernel/devices/ide/struct.IdeDevice.html#method.read_sync
 [keyboard]: {ROOT_PATH}docs/kernel/io/keyboard
-[keyboard_get_next_char]: {ROOT_PATH}docs/kernel/io/keyboard/struct.Keyboard.html#method.get_next_char
+[keyboard_get_reader]: {ROOT_PATH}docs/kernel/io/keyboard/struct.Keyboard.html#method.get_reader
 [uart]: {ROOT_PATH}docs/kernel/io/uart
 [console]: {ROOT_PATH}docs/kernel/io/console
 [kernel_filesystem]: {ROOT_PATH}docs/kernel/fs
@@ -43,3 +43,4 @@
 [clocks]: {ROOT_PATH}docs/kernel/devices/clock
 [vga]: {ROOT_PATH}docs/kernel/graphics/vga
 [framebufferinfo]: {ROOT_PATH}docs/kernel/graphics/vga/struct.FrameBufferInfo.html
+[keyboard_device]: {ROOT_PATH}docs/kernel/devices/keyboard

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -10,3 +10,4 @@ kernel_user_link = { version="0.2.0", path = "../libraries/kernel_user_link", pa
 increasing_heap_allocator = { version="0.1.3", path = "../libraries/increasing_heap_allocator" }
 embedded-graphics = { version = "0.8.1", default-features = false }
 byteorder = { version = "1.5", default-features = false }
+blinkcast = "0.2"

--- a/kernel/src/collections/ring.rs
+++ b/kernel/src/collections/ring.rs
@@ -64,6 +64,7 @@ impl<T, const N: usize> RingBuffer<T, N> {
     }
 }
 
+#[allow(dead_code)]
 impl<T: Copy, const N: usize> RingBuffer<T, N> {
     pub const fn empty() -> Self {
         Self {

--- a/kernel/src/devices/keyboard.rs
+++ b/kernel/src/devices/keyboard.rs
@@ -1,0 +1,72 @@
+//! Reading keyboard events from [`KeyboardReader`]
+
+use core::fmt;
+
+use alloc::sync::Arc;
+
+use crate::{
+    io::keyboard::{self, Key, KeyboardReader},
+    sync::spin::mutex::Mutex,
+};
+
+use super::Device;
+
+/// This is just a helper definition, and should not be used directly in any file
+#[derive(Debug)]
+pub struct KeyboardDeviceCreator;
+
+impl Device for KeyboardDeviceCreator {
+    fn name(&self) -> &str {
+        "keyboard"
+    }
+
+    fn clone_device(&self) -> Result<(), crate::fs::FileSystemError> {
+        Err(crate::fs::FileSystemError::OperationNotSupported)
+    }
+
+    fn try_create(&self) -> Option<Result<Arc<dyn Device>, crate::fs::FileSystemError>> {
+        Some(Ok(Arc::new(KeyboardDevice {
+            reader: Mutex::new(keyboard::get_keyboard_reader()),
+        })))
+    }
+}
+
+pub struct KeyboardDevice {
+    reader: Mutex<KeyboardReader>,
+}
+
+impl fmt::Debug for KeyboardDevice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "KeyboardDevice")
+    }
+}
+
+impl Device for KeyboardDevice {
+    fn name(&self) -> &str {
+        "keyboard_instance"
+    }
+
+    fn read(&self, _offset: u64, buf: &mut [u8]) -> Result<u64, crate::fs::FileSystemError> {
+        if buf.len() < Key::BYTES_SIZE {
+            return Err(crate::fs::FileSystemError::BufferNotLargeEnough(
+                Key::BYTES_SIZE,
+            ));
+        }
+
+        let mut reader = self.reader.lock();
+
+        let mut i = 0;
+
+        while i + Key::BYTES_SIZE <= buf.len() {
+            if let Some(key) = reader.recv() {
+                let key_bytes = key.as_bytes();
+                buf[i..i + Key::BYTES_SIZE].copy_from_slice(&key_bytes);
+                i += Key::BYTES_SIZE;
+            } else {
+                break;
+            }
+        }
+
+        Ok(i as u64)
+    }
+}

--- a/kernel/src/devices/mod.rs
+++ b/kernel/src/devices/mod.rs
@@ -41,6 +41,13 @@ pub trait Device: Sync + Send + fmt::Debug {
     fn clone_device(&self) -> Result<(), FileSystemError> {
         Ok(())
     }
+    /// Open the device.
+    /// This tells the device manager that when opening a file with this device name, it should
+    /// instead use the device returned by this function.
+    /// if `None`, it will just use the device directly.
+    fn try_create(&self) -> Option<Result<Arc<dyn Device>, FileSystemError>> {
+        None
+    }
 }
 
 impl FileSystem for RwLock<Devices> {

--- a/kernel/src/devices/mod.rs
+++ b/kernel/src/devices/mod.rs
@@ -8,10 +8,14 @@ use crate::{
     sync::{once::OnceLock, spin::rwlock::RwLock},
 };
 
-use self::pci::{PciDeviceConfig, PciDevicePropeIterator};
+use self::{
+    keyboard::KeyboardDeviceCreator,
+    pci::{PciDeviceConfig, PciDevicePropeIterator},
+};
 
 pub mod clock;
 pub mod ide;
+pub mod keyboard;
 pub mod pci;
 pub mod pipe;
 
@@ -138,5 +142,6 @@ pub fn probe_pci_driver(pci_device: &PciDeviceConfig) -> bool {
 
 /// Devices such as PS/2 keyboard, mouse, serial ports, etc.
 pub fn init_legacy_devices() {
-    io::keyboard::init_keyboard()
+    io::keyboard::init_keyboard();
+    register_device(Arc::new(KeyboardDeviceCreator));
 }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -356,7 +356,9 @@ pub enum FileSystemError {
     InvalidData,
     ReadNotSupported,
     WriteNotSupported,
+    OperationNotSupported,
     EndOfFile,
+    BufferNotLargeEnough(usize),
 }
 
 fn get_mapping(path: &Path) -> Result<(&Path, Arc<dyn FileSystem>), FileSystemError> {
@@ -489,6 +491,7 @@ pub enum FilesystemNode {
     Directory(Directory),
 }
 
+#[allow(dead_code)]
 impl File {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, FileSystemError> {
         Self::open_blocking(path, BlockingMode::None)

--- a/kernel/src/io/console.rs
+++ b/kernel/src/io/console.rs
@@ -437,7 +437,7 @@ impl Console for LateConsole {
             if let Some(c) = self
                 .keyboard
                 .recv()
-                .and_then(|c| if c.pressed { c.virtual_char } else { None })
+                .and_then(|c| if c.pressed { c.virtual_char() } else { None })
                 .or_else(read_uart)
             {
                 dst[i] = c;

--- a/kernel/src/io/keyboard.rs
+++ b/kernel/src/io/keyboard.rs
@@ -5,6 +5,7 @@ use core::{
 
 use alloc::sync::Arc;
 use blinkcast::alloc::{Receiver as BlinkcastReceiver, Sender as BlinkcastSender};
+pub use kernel_user_link::keyboard::{modifier, Key, KeyType};
 
 use crate::{
     cpu::{
@@ -51,268 +52,77 @@ const KEYBOARD_INT_NUM: u8 = 1;
 const KEYBOARD_STATUS_PORT: u16 = 0x64;
 const KEYBOARD_DATA_PORT: u16 = 0x60;
 
-/// The index is `KeyType`
-const US_KEYTYPE_KEYMAP: [u8; 127] = [
-    0, 27, b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'0', b'-', b'=', b'\x08', b'\t',
-    b'q', b'w', b'e', b'r', b't', b'y', b'u', b'i', b'o', b'p', b'[', b']', b'\n', 0, b'a', b's',
-    b'd', b'f', b'g', b'h', b'j', b'k', b'l', b';', b'\'', b'`', 0, b'\\', b'z', b'x', b'c', b'v',
-    b'b', b'n', b'm', b',', b'.', b'/', 0, b'*', 0, b' ', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    b'7', b'8', b'9', b'-', b'4', b'5', b'6', b'+', b'1', b'2', b'3', b'0', b'.', 0, 0, 0, 0, 0, 0,
-    0, b'\n', 0, 0, 0, 0, 0, 0, 0, 0, b'/', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0,
-];
+// 0x80 means extended key
+fn key_type_from_device(value: u8) -> Option<KeyType> {
+    if value & 0x80 == 0 {
+        if value <= KeyType::F12 as u8 {
+            // not extended.
+            // we know that we are mapping the not extended keys directly
+            // so we can just cast it
+            let k = unsafe { core::mem::transmute(value) };
+            if k == KeyType::_None1
+                || k == KeyType::_None2
+                || k == KeyType::_None3
+                || k == KeyType::_None4
+            {
+                return None;
+            }
 
-/// The index is `KeyType`
-const US_KEYTYPE_KEYMAP_SHIFTED: [u8; 127] = [
-    0, 27, b'!', b'@', b'#', b'$', b'%', b'^', b'&', b'*', b'(', b')', b'_', b'+', b'\x08', b'\t',
-    b'Q', b'W', b'E', b'R', b'T', b'Y', b'U', b'I', b'O', b'P', b'{', b'}', b'\n', 0, b'A', b'S',
-    b'D', b'F', b'G', b'H', b'J', b'K', b'L', b':', b'"', b'~', 0, b'|', b'Z', b'X', b'C', b'V',
-    b'B', b'N', b'M', b'<', b'>', b'?', 0, b'*', 0, b' ', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, b'-', 0, b'5', 0, b'+', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-];
-
-#[allow(dead_code)]
-#[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum KeyType {
-    // normal keys (mapped 1:1 with set 1 scan codes)
-    _None1,
-    Escape,
-    Num1,
-    Num2,
-    Num3,
-    Num4,
-    Num5,
-    Num6,
-    Num7,
-    Num8,
-    Num9,
-    Num0,
-    Minus,
-    Equals,
-    Backspace,
-    Tab,
-    Q,
-    W,
-    E,
-    R,
-    T,
-    Y,
-    U,
-    I,
-    O,
-    P,
-    LeftBracket,
-    RightBracket,
-    Enter,
-    LeftCtrl,
-    A,
-    S,
-    D,
-    F,
-    G,
-    H,
-    J,
-    K,
-    L,
-    Semicolon,
-    SingleQuote,
-    Backtick,
-    LeftShift,
-    Backslash,
-    Z,
-    X,
-    C,
-    V,
-    B,
-    N,
-    M,
-    Comma,
-    Dot,
-    Slash,
-    RightShift,
-    KeypadAsterisk,
-    LeftAlt,
-    Space,
-    CapsLock,
-    F1,
-    F2,
-    F3,
-    F4,
-    F5,
-    F6,
-    F7,
-    F8,
-    F9,
-    F10,
-    NumLock,
-    ScrollLock,
-    Keypad7,
-    Keypad8,
-    Keypad9,
-    KeypadMinus,
-    Keypad4,
-    Keypad5,
-    Keypad6,
-    KeypadPlus,
-    Keypad1,
-    Keypad2,
-    Keypad3,
-    Keypad0,
-    KeypadDot,
-    _None2,
-    _None3,
-    _None4,
-    F11,
-    F12,
-
-    // extended keys
-    MultimediaPreviousTrack,
-    MultimediaNextTrack,
-    KeypadEnter,
-    RightCtrl,
-    MultimediaMute,
-    Calculator,
-    MultimediaPlayPause,
-    MultimediaStop,
-    VolumeDown,
-    VolumeUp,
-    WWWHome,
-    KeypadSlash,
-    RightAlt,
-    Home,
-    UpArrow,
-    PageUp,
-    LeftArrow,
-    RightArrow,
-    End,
-    DownArrow,
-    PageDown,
-    Insert,
-    Delete,
-    LeftGUI,
-    RightGUI,
-    Application,
-    Power,
-    Sleep,
-    Wake,
-    WWWSearch,
-    WWWFavorites,
-    WWWRefresh,
-    WWWStop,
-    WWWForward,
-    WWWBack,
-    MyComputer,
-    Email,
-    MultimediaSelect,
-}
-
-impl KeyType {
-    pub fn virtual_key(&self, shifted: bool) -> Option<u8> {
-        let index = *self as usize;
-        let mappings = if shifted {
-            &US_KEYTYPE_KEYMAP_SHIFTED
+            Some(k)
         } else {
-            &US_KEYTYPE_KEYMAP
-        };
-
-        assert!(index < mappings.len());
-        let value = mappings[index];
-
-        if value == 0 {
+            // not a valid key
             None
-        } else {
-            Some(value)
         }
-    }
-}
+    } else {
+        // first, strip the extension
+        let key = value & !0x80;
 
-impl TryFrom<u8> for KeyType {
-    type Error = ();
-
-    // 0x80 means extended key
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        if value & 0x80 == 0 {
-            if value <= Self::F12 as u8 {
-                // not extended.
-                // we know that we are mapping the not extended keys directly
-                // so we can just cast it
-                let k = unsafe { core::mem::transmute(value) };
-                if k == Self::_None1 || k == Self::_None2 || k == Self::_None3 || k == Self::_None4
-                {
-                    return Err(());
-                }
-
-                Ok(k)
-            } else {
-                // not a valid key
-                Err(())
-            }
-        } else {
-            // first, strip the extension
-            let key = value & !0x80;
-
-            // use match normally
-            match key {
-                0x10 => Ok(Self::MultimediaPreviousTrack),
-                0x19 => Ok(Self::MultimediaNextTrack),
-                0x1C => Ok(Self::KeypadEnter),
-                0x1D => Ok(Self::RightCtrl),
-                0x20 => Ok(Self::MultimediaMute),
-                0x21 => Ok(Self::Calculator),
-                0x22 => Ok(Self::MultimediaPlayPause),
-                0x24 => Ok(Self::MultimediaStop),
-                0x2E => Ok(Self::VolumeDown),
-                0x30 => Ok(Self::VolumeUp),
-                0x32 => Ok(Self::WWWHome),
-                0x35 => Ok(Self::KeypadSlash),
-                0x38 => Ok(Self::RightAlt),
-                0x47 => Ok(Self::Home),
-                0x48 => Ok(Self::UpArrow),
-                0x49 => Ok(Self::PageUp),
-                0x4B => Ok(Self::LeftArrow),
-                0x4D => Ok(Self::RightArrow),
-                0x4F => Ok(Self::End),
-                0x50 => Ok(Self::DownArrow),
-                0x51 => Ok(Self::PageDown),
-                0x52 => Ok(Self::Insert),
-                0x53 => Ok(Self::Delete),
-                0x5B => Ok(Self::LeftGUI),
-                0x5C => Ok(Self::RightGUI),
-                0x5D => Ok(Self::Application),
-                0x5E => Ok(Self::Power),
-                0x5F => Ok(Self::Sleep),
-                0x63 => Ok(Self::Wake),
-                0x65 => Ok(Self::WWWSearch),
-                0x66 => Ok(Self::WWWFavorites),
-                0x67 => Ok(Self::WWWRefresh),
-                0x68 => Ok(Self::WWWStop),
-                0x69 => Ok(Self::WWWForward),
-                0x6A => Ok(Self::WWWBack),
-                0x6B => Ok(Self::MyComputer),
-                0x6C => Ok(Self::Email),
-                0x6D => Ok(Self::MultimediaSelect),
-                _ => Err(()),
-            }
+        // use match normally
+        match key {
+            0x10 => Some(KeyType::MultimediaPreviousTrack),
+            0x19 => Some(KeyType::MultimediaNextTrack),
+            0x1C => Some(KeyType::KeypadEnter),
+            0x1D => Some(KeyType::RightCtrl),
+            0x20 => Some(KeyType::MultimediaMute),
+            0x21 => Some(KeyType::Calculator),
+            0x22 => Some(KeyType::MultimediaPlayPause),
+            0x24 => Some(KeyType::MultimediaStop),
+            0x2E => Some(KeyType::VolumeDown),
+            0x30 => Some(KeyType::VolumeUp),
+            0x32 => Some(KeyType::WWWHome),
+            0x35 => Some(KeyType::KeypadSlash),
+            0x38 => Some(KeyType::RightAlt),
+            0x47 => Some(KeyType::Home),
+            0x48 => Some(KeyType::UpArrow),
+            0x49 => Some(KeyType::PageUp),
+            0x4B => Some(KeyType::LeftArrow),
+            0x4D => Some(KeyType::RightArrow),
+            0x4F => Some(KeyType::End),
+            0x50 => Some(KeyType::DownArrow),
+            0x51 => Some(KeyType::PageDown),
+            0x52 => Some(KeyType::Insert),
+            0x53 => Some(KeyType::Delete),
+            0x5B => Some(KeyType::LeftGUI),
+            0x5C => Some(KeyType::RightGUI),
+            0x5D => Some(KeyType::Application),
+            0x5E => Some(KeyType::Power),
+            0x5F => Some(KeyType::Sleep),
+            0x63 => Some(KeyType::Wake),
+            0x65 => Some(KeyType::WWWSearch),
+            0x66 => Some(KeyType::WWWFavorites),
+            0x67 => Some(KeyType::WWWRefresh),
+            0x68 => Some(KeyType::WWWStop),
+            0x69 => Some(KeyType::WWWForward),
+            0x6A => Some(KeyType::WWWBack),
+            0x6B => Some(KeyType::MyComputer),
+            0x6C => Some(KeyType::Email),
+            0x6D => Some(KeyType::MultimediaSelect),
+            _ => None,
         }
     }
 }
 
 #[allow(dead_code)]
-mod modifier {
-    pub const SHIFT: u8 = 1 << 0;
-    pub const CTRL: u8 = 1 << 1;
-    pub const ALT: u8 = 1 << 2;
-
-    pub const CAPS_LOCK: u8 = 1 << 3;
-    pub const NUM_LOCK: u8 = 1 << 4;
-    pub const SCROLL_LOCK: u8 = 1 << 5;
-    pub const EXTENDED: u8 = 1 << 6;
-
-    // a way to compress the `bytes` value
-    pub const PRESSED: u8 = 1 << 7;
-}
 
 const fn get_modifier(key: u8) -> Option<u8> {
     match key {
@@ -345,48 +155,6 @@ mod status {
     pub const KEYBOARD_TIMEOUT_MOUSE_DATA: u8 = 1 << 5;
     pub const RECEIVE_TIMEOUT: u8 = 1 << 6;
     pub const PARITY_ERROR: u8 = 1 << 7;
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Key {
-    pub pressed: bool,
-    pub modifiers: u8,
-    pub key_type: KeyType,
-}
-
-impl Key {
-    pub const BYTES_SIZE: usize = 2;
-
-    /// # Safety
-    /// The `bytes` must be a valid representation of a `Key`
-    /// that has been created by `as_bytes`
-    #[allow(dead_code)]
-    pub unsafe fn from_bytes(bytes: [u8; Self::BYTES_SIZE]) -> Self {
-        let pressed = bytes[0] & modifier::PRESSED == 0;
-        let modifiers = bytes[0] & !modifier::PRESSED;
-        // Safety: we know that the `bytes` is a valid representation of `KeyType`
-        //         responsability of the caller to ensure that
-        let key_type = core::mem::transmute(bytes[1]);
-
-        Self {
-            pressed,
-            modifiers,
-            key_type,
-        }
-    }
-
-    pub fn as_bytes(&self) -> [u8; 2] {
-        let mut bytes = [0; 2];
-        bytes[0] = (self.modifiers & !modifier::PRESSED)
-            | if self.pressed { modifier::PRESSED } else { 0 };
-        bytes[1] = self.key_type as u8;
-        bytes
-    }
-
-    pub fn virtual_char(&self) -> Option<u8> {
-        let shifted = self.modifiers & modifier::SHIFT != 0;
-        self.key_type.virtual_key(shifted)
-    }
 }
 
 pub type KeyboardReader = BlinkcastReceiver<Key>;
@@ -440,7 +208,7 @@ impl Keyboard {
             // this is an extended key
             let data = self.read_data();
             let pressed = data & KEY_PRESSED == 0;
-            let key = (data | 0x80).try_into().ok()?;
+            let key = key_type_from_device(data | 0x80)?;
 
             return Some(Key {
                 pressed,
@@ -477,7 +245,7 @@ impl Keyboard {
             }
         }
         // this is a normal key
-        let key_type: KeyType = data.try_into().ok()?;
+        let key_type = key_type_from_device(data)?;
 
         Some(Key {
             pressed,

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -62,10 +62,12 @@ impl From<FileSystemError> for SyscallError {
             FileSystemError::IsNotDirectory => SyscallError::IsNotDirectory,
             FileSystemError::IsDirectory => SyscallError::IsDirectory,
             FileSystemError::DeviceNotFound => todo!(),
+            FileSystemError::BufferNotLargeEnough(_) => SyscallError::BufferTooSmall,
             FileSystemError::DiskReadError { .. }
             | FileSystemError::InvalidOffset
             | FileSystemError::FatError(_)
             | FileSystemError::InvalidData
+            | FileSystemError::OperationNotSupported
             | FileSystemError::MustBeAbsolute   // should not happen from user mode
             | FileSystemError::PartitionTableNotFound => panic!("should not happen?"),
         }

--- a/libraries/emerald_std/Cargo.toml
+++ b/libraries/emerald_std/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["os"]
 
 [dependencies]
 increasing_heap_allocator = { version="0.1.3", path = "../increasing_heap_allocator" }
-kernel_user_link = { version="0.2.4", path = "../kernel_user_link", package = "emerald_kernel_user_link" }
+kernel_user_link = { version="0.2.5", path = "../kernel_user_link", package = "emerald_kernel_user_link" }
 # for now, waiting for the PR https://github.com/rust-lang/libm/pull/290 to be merged
 libm = { version = "0.2.8", git = "https://github.com/Amjad50/libm", branch = "compiling_libm_for_std" }
 

--- a/libraries/kernel_user_link/Cargo.toml
+++ b/libraries/kernel_user_link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_kernel_user_link"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]

--- a/libraries/kernel_user_link/src/keyboard.rs
+++ b/libraries/kernel_user_link/src/keyboard.rs
@@ -1,0 +1,232 @@
+pub const KEYBOARD_PATH: &str = "/devices/keyboard";
+
+pub mod modifier {
+    pub const SHIFT: u8 = 1 << 0;
+    pub const CTRL: u8 = 1 << 1;
+    pub const ALT: u8 = 1 << 2;
+
+    pub const CAPS_LOCK: u8 = 1 << 3;
+    pub const NUM_LOCK: u8 = 1 << 4;
+    pub const SCROLL_LOCK: u8 = 1 << 5;
+    pub const EXTENDED: u8 = 1 << 6;
+
+    // a way to compress the `bytes` value
+    pub const PRESSED: u8 = 1 << 7;
+}
+
+/// The index is `KeyType`
+const US_KEYTYPE_KEYMAP: [u8; 127] = [
+    0, 27, b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'0', b'-', b'=', b'\x08', b'\t',
+    b'q', b'w', b'e', b'r', b't', b'y', b'u', b'i', b'o', b'p', b'[', b']', b'\n', 0, b'a', b's',
+    b'd', b'f', b'g', b'h', b'j', b'k', b'l', b';', b'\'', b'`', 0, b'\\', b'z', b'x', b'c', b'v',
+    b'b', b'n', b'm', b',', b'.', b'/', 0, b'*', 0, b' ', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    b'7', b'8', b'9', b'-', b'4', b'5', b'6', b'+', b'1', b'2', b'3', b'0', b'.', 0, 0, 0, 0, 0, 0,
+    0, b'\n', 0, 0, 0, 0, 0, 0, 0, 0, b'/', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+/// The index is `KeyType`
+const US_KEYTYPE_KEYMAP_SHIFTED: [u8; 127] = [
+    0, 27, b'!', b'@', b'#', b'$', b'%', b'^', b'&', b'*', b'(', b')', b'_', b'+', b'\x08', b'\t',
+    b'Q', b'W', b'E', b'R', b'T', b'Y', b'U', b'I', b'O', b'P', b'{', b'}', b'\n', 0, b'A', b'S',
+    b'D', b'F', b'G', b'H', b'J', b'K', b'L', b':', b'"', b'~', 0, b'|', b'Z', b'X', b'C', b'V',
+    b'B', b'N', b'M', b'<', b'>', b'?', 0, b'*', 0, b' ', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, b'-', 0, b'5', 0, b'+', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum KeyType {
+    // normal keys (mapped 1:1 with set 1 scan codes)
+    _None1,
+    Escape,
+    Num1,
+    Num2,
+    Num3,
+    Num4,
+    Num5,
+    Num6,
+    Num7,
+    Num8,
+    Num9,
+    Num0,
+    Minus,
+    Equals,
+    Backspace,
+    Tab,
+    Q,
+    W,
+    E,
+    R,
+    T,
+    Y,
+    U,
+    I,
+    O,
+    P,
+    LeftBracket,
+    RightBracket,
+    Enter,
+    LeftCtrl,
+    A,
+    S,
+    D,
+    F,
+    G,
+    H,
+    J,
+    K,
+    L,
+    Semicolon,
+    SingleQuote,
+    Backtick,
+    LeftShift,
+    Backslash,
+    Z,
+    X,
+    C,
+    V,
+    B,
+    N,
+    M,
+    Comma,
+    Dot,
+    Slash,
+    RightShift,
+    KeypadAsterisk,
+    LeftAlt,
+    Space,
+    CapsLock,
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    NumLock,
+    ScrollLock,
+    Keypad7,
+    Keypad8,
+    Keypad9,
+    KeypadMinus,
+    Keypad4,
+    Keypad5,
+    Keypad6,
+    KeypadPlus,
+    Keypad1,
+    Keypad2,
+    Keypad3,
+    Keypad0,
+    KeypadDot,
+    _None2,
+    _None3,
+    _None4,
+    F11,
+    F12,
+
+    // extended keys
+    MultimediaPreviousTrack,
+    MultimediaNextTrack,
+    KeypadEnter,
+    RightCtrl,
+    MultimediaMute,
+    Calculator,
+    MultimediaPlayPause,
+    MultimediaStop,
+    VolumeDown,
+    VolumeUp,
+    WWWHome,
+    KeypadSlash,
+    RightAlt,
+    Home,
+    UpArrow,
+    PageUp,
+    LeftArrow,
+    RightArrow,
+    End,
+    DownArrow,
+    PageDown,
+    Insert,
+    Delete,
+    LeftGUI,
+    RightGUI,
+    Application,
+    Power,
+    Sleep,
+    Wake,
+    WWWSearch,
+    WWWFavorites,
+    WWWRefresh,
+    WWWStop,
+    WWWForward,
+    WWWBack,
+    MyComputer,
+    Email,
+    MultimediaSelect,
+}
+
+impl KeyType {
+    pub fn virtual_key(&self, shifted: bool) -> Option<u8> {
+        let index = *self as usize;
+        let mappings = if shifted {
+            &US_KEYTYPE_KEYMAP_SHIFTED
+        } else {
+            &US_KEYTYPE_KEYMAP
+        };
+
+        assert!(index < mappings.len());
+        let value = mappings[index];
+
+        if value == 0 {
+            None
+        } else {
+            Some(value)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Key {
+    pub pressed: bool,
+    pub modifiers: u8,
+    pub key_type: KeyType,
+}
+
+impl Key {
+    pub const BYTES_SIZE: usize = 2;
+
+    /// # Safety
+    /// The `bytes` must be a valid representation of a `Key`
+    /// that has been created by `as_bytes`
+    pub unsafe fn from_bytes(bytes: [u8; Self::BYTES_SIZE]) -> Self {
+        let pressed = bytes[0] & modifier::PRESSED != 0;
+        let modifiers = bytes[0] & !modifier::PRESSED;
+        // Safety: we know that the `bytes` is a valid representation of `KeyType`
+        //         responsability of the caller to ensure that
+        let key_type = core::mem::transmute(bytes[1]);
+
+        Self {
+            pressed,
+            modifiers,
+            key_type,
+        }
+    }
+
+    pub fn as_bytes(&self) -> [u8; 2] {
+        let mut bytes = [0; 2];
+        bytes[0] = (self.modifiers & !modifier::PRESSED)
+            | if self.pressed { modifier::PRESSED } else { 0 };
+        bytes[1] = self.key_type as u8;
+        bytes
+    }
+
+    pub fn virtual_char(&self) -> Option<u8> {
+        let shifted = self.modifiers & modifier::SHIFT != 0;
+        self.key_type.virtual_key(shifted)
+    }
+}

--- a/libraries/kernel_user_link/src/lib.rs
+++ b/libraries/kernel_user_link/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod clock;
 pub mod file;
 pub mod graphics;
+pub mod keyboard;
 pub mod process;
 pub mod syscalls;
 

--- a/libraries/keyboard/Cargo.toml
+++ b/libraries/keyboard/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "emerald_keyboard"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+kernel_user_link = { version="0.2.5", path = "../kernel_user_link", package = "emerald_kernel_user_link" }

--- a/libraries/keyboard/Cargo.toml
+++ b/libraries/keyboard/Cargo.toml
@@ -2,8 +2,13 @@
 name = "emerald_keyboard"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+readme = "README.md"
+authors = ["Amjad Alsharafi"]
+license = "MIT"
+repository = "https://github.com/Amjad50/Emerald"
+description = "userspace keyboard events reader for Emerald OS"
+keywords = ["userspace", "keyboard", "os"]
+categories = ["os"]
 
 [dependencies]
 kernel_user_link = { version="0.2.5", path = "../kernel_user_link", package = "emerald_kernel_user_link" }

--- a/libraries/keyboard/README.md
+++ b/libraries/keyboard/README.md
@@ -1,0 +1,8 @@
+### Emerald: keyboard userspace driver
+
+[![Crates.io emerald_keyboard](https://img.shields.io/crates/v/emerald_keyboard)](https://crates.io/crates/emerald_keyboard)
+[![docs.rs (with version)](https://img.shields.io/docsrs/emerald_keyboard/latest)](https://docs.rs/emerald_keyboard/latest/emerald_keyboard/)
+
+This is a small library that provide keyboard functionalities to userspace programs in `Emerald`.
+
+See: https://github.com/Amjad50/Emerald

--- a/libraries/keyboard/src/lib.rs
+++ b/libraries/keyboard/src/lib.rs
@@ -1,0 +1,42 @@
+use std::{fs::File, io::Read, thread::sleep};
+
+use kernel_user_link::keyboard::KEYBOARD_PATH;
+pub use kernel_user_link::keyboard::{modifier, Key, KeyType};
+
+pub struct Keyboard {
+    file: File,
+}
+
+impl Keyboard {
+    pub fn new() -> Self {
+        let file = File::open(KEYBOARD_PATH).unwrap();
+        Keyboard { file }
+    }
+
+    pub fn get_key_event(&mut self) -> Option<Key> {
+        let mut buf = [0; Key::BYTES_SIZE];
+        if self.file.read(&mut buf).unwrap() == Key::BYTES_SIZE {
+            // Safety: we are using the same size as the Key struct
+            // and this is provided by the kernel, so it must
+            // be valid
+            Some(unsafe { Key::from_bytes(buf) })
+        } else {
+            None
+        }
+    }
+
+    pub fn iter_keys(&mut self) -> impl Iterator<Item = Key> + '_ {
+        std::iter::from_fn(move || self.get_key_event())
+    }
+
+    // TODO: this is a temporary solution, we should use a better way to wait for input
+    pub fn wait_for_input(&mut self) -> Key {
+        loop {
+            if let Some(key) = self.get_key_event() {
+                return key;
+            }
+            // core::hint::spin_loop();
+            sleep(std::time::Duration::from_millis(10));
+        }
+    }
+}

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -43,4 +43,10 @@ workspace = false
 dependencies = ["build_member"]
 condition= {files_modified = {input=["${USER_OUTDIR}/${CARGO_MAKE_PROJECT_NAME}"], output=["${FILESYSTEM_PATH}/${CARGO_MAKE_PROJECT_NAME}"]}}
 command = "cp"
-args = ["-r", "${USER_OUTDIR}/echo", "${USER_OUTDIR}/cat", "${USER_OUTDIR}/ls", "${USER_OUTDIR}/xxd", "${USER_OUTDIR}/graphics", "${FILESYSTEM_PATH}/"]
+args = ["-r", "${USER_OUTDIR}/echo",
+              "${USER_OUTDIR}/cat",
+              "${USER_OUTDIR}/ls",
+              "${USER_OUTDIR}/xxd",
+              "${USER_OUTDIR}/keyboard",
+              "${USER_OUTDIR}/graphics",
+              "${FILESYSTEM_PATH}/"]

--- a/userspace/shell/Cargo.toml
+++ b/userspace/shell/Cargo.toml
@@ -25,5 +25,10 @@ path = "src/shell.rs"
 name = "xxd"
 path = "src/xxd.rs"
 
+[[bin]]
+name = "keyboard"
+path = "src/keyboard.rs"
+
 [dependencies]
 colored = "2.1.0"
+emerald_keyboard = { path = "../../libraries/keyboard"}

--- a/userspace/shell/src/keyboard.rs
+++ b/userspace/shell/src/keyboard.rs
@@ -1,0 +1,19 @@
+use colored::Colorize;
+use emerald_keyboard::{KeyType, Keyboard};
+
+fn main() {
+    println!("Keyboard debugging tool. Press {} to exit:", "ESC".blue());
+
+    // stay in a loop, read the keyboard input and print it
+    // exit on ESC key
+    let mut keyboard = Keyboard::new();
+    loop {
+        if let Some(key) = keyboard.get_key_event() {
+            let press = if key.pressed { "+".green() } else { "-".red() };
+            println!("[{press}] {}", format!("{:?}", key.key_type).blue());
+            if key.key_type == KeyType::Escape {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Provided API for userspace processes to access keyboard events.

This will help us create the next generation of GUI applications XD.


### Related issue
Fixes #49  


## Changes

- Added `/devices/keyboard` device, which give u provide ability to read keyboard events.
- Added `emerald_keyboard` https://crates.io/crates/emerald_keyboard to handle keyboard management and reading of that file.
- Moved parts of the keyboard code into `kernel_user_link` so that user+kernel code can use it easily.


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
