### PR TITLE
Kernel stack unwinding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "graphics"
 version = "0.1.0"
 dependencies = [
@@ -232,6 +238,7 @@ dependencies = [
  "embedded-graphics",
  "emerald_kernel_user_link",
  "increasing_heap_allocator",
+ "unwinding",
 ]
 
 [[package]]
@@ -537,6 +544,15 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unwinding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a19a21a537f635c16c7576f22d0f2f7d63353c1337ad4ce0d8001c7952a25b"
+dependencies = [
+ "gimli",
+]
 
 [[package]]
 name = "valuable"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -11,3 +11,4 @@ increasing_heap_allocator = { version="0.1.3", path = "../libraries/increasing_h
 embedded-graphics = { version = "0.8.1", default-features = false }
 byteorder = { version = "1.5", default-features = false }
 blinkcast = "0.2"
+unwinding = { version = "0.2", features = ['unwinder', 'personality', 'fde-static'], default-features = false }

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -22,6 +22,12 @@ SECTIONS {
         *(.rodata .rodata.*)
     } : kernel_ro
 
+    . = ALIGN(8);
+    PROVIDE(__eh_frame = .);
+    .eh_frame : {
+        KEEP (*(.eh_frame)) *(.eh_frame.*)
+    } : kernel_ro
+
     /* Adjust the address for the data segment to the next page */
     . = ALIGN(4K);
 
@@ -43,15 +49,12 @@ SECTIONS {
     } : kernel_rw
 
     PROVIDE(end = .);
-
-    /DISCARD/ :
-    {
-        *(.eh_frame .eh_frame*)
-    }
 }
 
 multiboot_load_addr = load_addr;
 multiboot_load_end = load_addr + (data_end - begin);
 multiboot_bss_end = load_addr + (end - begin);
 multiboot_entry_addr = load_addr + (entry - begin);
+__executable_start = load_addr;
+__etext = text_end;
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -23,10 +23,9 @@ mod graphics;
 mod io;
 mod memory_management;
 mod multiboot2;
+mod panic_handler;
 mod process;
 mod sync;
-
-use core::hint;
 
 use alloc::vec::Vec;
 use cpu::{
@@ -146,16 +145,4 @@ pub extern "C" fn kernel_main(multiboot_info: &MultiBoot2Info) -> ! {
 
     // this will never return
     scheduler::schedule()
-}
-
-#[panic_handler]
-fn panic(info: &core::panic::PanicInfo) -> ! {
-    unsafe { cpu::clear_interrupts() };
-    println!("{info}");
-    loop {
-        unsafe {
-            cpu::halt();
-        }
-        hint::spin_loop();
-    }
 }

--- a/kernel/src/panic_handler.rs
+++ b/kernel/src/panic_handler.rs
@@ -1,0 +1,64 @@
+use core::{
+    ffi::c_void,
+    hint,
+    panic::PanicInfo,
+    sync::atomic::{AtomicI32, Ordering},
+};
+
+use unwinding::abi::{UnwindContext, UnwindReasonCode, _Unwind_Backtrace, _Unwind_GetIP};
+
+use crate::cpu;
+
+// this should be 'core-local/thread-local', but that's okay, as we want to halt the whole kernel
+static PANIC_COUNT: AtomicI32 = AtomicI32::new(0);
+
+fn stack_trace() {
+    struct CallbackData {
+        counter: usize,
+    }
+    extern "C" fn callback(unwind_ctx: &UnwindContext<'_>, arg: *mut c_void) -> UnwindReasonCode {
+        let data = unsafe { &mut *(arg as *mut CallbackData) };
+        data.counter += 1;
+        println!("{:4}:{:#19x}", data.counter, _Unwind_GetIP(unwind_ctx));
+        UnwindReasonCode::NO_REASON
+    }
+    let mut data = CallbackData { counter: 0 };
+    _Unwind_Backtrace(callback, &mut data as *mut _ as _);
+
+    print!("You can use this command to get information about the trace (since we don't have debug symbols here):\n$ addr2line -f -C -e ./target/x86-64-os/debug/kernel");
+    extern "C" fn callback2(unwind_ctx: &UnwindContext<'_>, _arg: *mut c_void) -> UnwindReasonCode {
+        print!(" {:#x}", _Unwind_GetIP(unwind_ctx));
+        UnwindReasonCode::NO_REASON
+    }
+    _Unwind_Backtrace(callback2, core::ptr::null_mut() as _);
+    println!("\nhalting...");
+}
+
+fn panic_trace() -> ! {
+    if PANIC_COUNT.load(Ordering::Relaxed) >= 1 {
+        stack_trace();
+        println!("thread panicked while processing panic. halting...");
+        abort();
+    }
+    PANIC_COUNT.store(1, Ordering::Relaxed);
+    stack_trace();
+    println!("failed to initiate panic, maybe, we don't have `eh_frame` data?. halting...");
+    abort()
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo<'_>) -> ! {
+    unsafe { cpu::clear_interrupts() };
+    println!("{}", info);
+
+    panic_trace()
+}
+
+fn abort() -> ! {
+    loop {
+        unsafe {
+            cpu::halt();
+        }
+        hint::spin_loop();
+    }
+}

--- a/kernel/x86-64-os.json
+++ b/kernel/x86-64-os.json
@@ -8,7 +8,7 @@
     "executables": true,
     "linker-flavor": "ld.lld",
     "linker": "rust-lld",
-    "panic-strategy": "abort",
+    "panic-strategy": "unwind",
     "disable-redzone": true,
     "features": "-mmx,-sse,+soft-float"
 }


### PR DESCRIPTION
Added stack unwinding for the kernel using https://github.com/nbdd0121/unwinding.


## Summary
Stack unwinding in the kernel, we don't get pretty symbols, as we don't have that loaded in memory yet.

### Related issue
More work in #81 


## Changes

<!-- Please provide some more detail regarding the changes.
Add any additional information, configuration, or data that might be necessary for the review
Mention the type of each change. i.e. `Addition`, `Bug Fix`, `Documentation`, etc... -->


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
