### PR TITLE
Toolchain distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           path: extern/rust/build/host/stage2
           key: ${{ steps.cache-os-rust-restore.outputs.cache-primary-key }}
+      - name: Build toolchain dist
+        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true' || steps.rust-changes.outputs.any_changed == 'true'
+        run: cargo make toolchain_dist
       - name: Upload kernel artifact
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v4
@@ -75,4 +78,10 @@ jobs:
           name: filesystem_programs
           path: filesystem
           overwrite: true
-
+      - name: Upload toolchain artifact
+        if: github.ref == 'refs/heads/master' && (steps.cache-os-rust-restore.outputs.cache-hit != 'true' || steps.rust-changes.outputs.any_changed == 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: toolchain
+          path: ./extern/rust/build/dist/(rustc-1*linux|rust-std|rustfmt)*.xz
+          overwrite: true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,6 +13,12 @@ cwd = "userspace"
 command = "cargo-make"
 args = ["make", "--makefile", "Makefile.toolchain.toml", "install_user_toolchain"]
 
+[tasks.toolchain_dist]
+workspace = false
+cwd = "userspace"
+command = "cargo-make"
+args = ["make", "--makefile", "Makefile.toolchain.toml", "dist_user_toolchain"]
+
 [tasks.filesystem]
 workspace = false
 cwd = "userspace"

--- a/tools/install_toolchain.sh
+++ b/tools/install_toolchain.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+
+# script used to install rust components into a prefix
+
+prefix=$(realpath $1)
+sysconfdir=$prefix/etc
+if [ -z $prefix ]; then
+    # panic
+    echo "Usage: $0 <prefix> [file1.tar.xz file2.tar.xz ...]"
+    exit 1
+fi
+
+# go through all the file names after the prefix
+shift
+
+# if there is no argument, print a warning
+if [ $# -eq 0 ]; then
+    echo "No components to install"
+    exit 1
+fi
+
+for file in $@; do
+    echo "Installing $file component"
+    # make sure this is xz
+    if [ ${file: -3} != ".xz" ]; then
+        echo "File $file is not an xz file"
+        exit 1
+    fi
+    # move into the folder of the xz file
+    pushd $(dirname $file)
+    # extract
+    tar -xf $file
+    # get the name of the directory
+    dir=$(basename $file .tar.xz)
+    # go into the directory
+    pushd $dir
+    # install
+    sh install.sh --prefix=$prefix --sysconfdir=$sysconfdir
+    # go back
+    popd
+    # remove the directory
+    rm -r $dir
+    # go back
+    popd
+done
+

--- a/tools/install_zipped_toolchain_and_link.sh
+++ b/tools/install_zipped_toolchain_and_link.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# install a zipped toolchain into the prefix found in `<this_file>/../extern/toolchain`
+# and link it with `rustup` to toolchain `emerald`
+
+zip_file=$1
+if [ -z $zip_file ]; then
+    echo "Usage: $0 <zip_file>"
+    exit 1
+fi
+
+if [ ! -f $zip_file ]; then
+    echo "File $zip_file does not exist"
+    exit 1
+fi
+
+# check zip extension
+if [ ${zip_file: -4} != ".zip" ]; then
+    echo "File $zip_file is not a zip file"
+    exit 1
+fi
+
+# get the directory of this file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# get the prefix
+prefix=$DIR/../extern/toolchain
+
+# extract the zip file into temp
+temp_dir=$(mktemp -d)
+unzip -q $zip_file -d $temp_dir
+
+# install the toolchain
+sh $DIR/install_toolchain.sh $prefix $temp_dir/*
+
+# link the toolchain
+rustup toolchain link emerald $prefix
+
+# remove the temp directory
+rm -r $temp_dir
+
+echo "Installed and linked \"$zip_file\" into \"$prefix\" and linked it with rustup as toolchain \`emerald\`"
+echo "You can use it with \`cargo +emerald build\`"

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -1,8 +1,9 @@
 [env]
-RUSTC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2/bin/rustc"
-RUSTDOC = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2/rustdoc"
 USER_OUTDIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/x86_64-unknown-emerald/${PROFILE}"
 CARGO_MAKE_CARGO_PROFILE = { source = "${PROFILE}", default_value = "debug", mapping = {"debug" = "dev", "release" = "release" } }
+USE_INSTALLED_TOOLCHAIN = { value = "false", condition = { env_not_set = ["USE_INSTALLED_TOOLCHAIN"] } }
+RUSTC = { source = "${USE_INSTALLED_TOOLCHAIN}", default_value = "false", mapping = {"false" = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2/bin/rustc", "true" = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/rustc" } }
+RUSTDOC = { source = "${USE_INSTALLED_TOOLCHAIN}", default_value = "false", mapping = {"false" = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/rust/build/host/stage2/bin/rustdoc", "true" = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../extern/toolchain/bin/rustdoc" } }
 
 
 CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = ["init", "shell", "graphics"]
@@ -16,6 +17,7 @@ CARGO_BUILD_TARGET = "x86_64-unknown-linux-gnu"
 # copy found in the root makefile
 [tasks.toolchain]
 workspace = false
+condition = { env_false = ["USE_INSTALLED_TOOLCHAIN"] }
 command = "cargo-make"
 args = ["make", "--makefile", "Makefile.toolchain.toml", "build_user_toolchain"]
 

--- a/userspace/Makefile.toolchain.toml
+++ b/userspace/Makefile.toolchain.toml
@@ -21,7 +21,14 @@ args = ["x.py", "build", "-i", "--stage", "2", "rustfmt", "library/std"]
 
 [tasks.install_user_toolchain]
 workspace = false
-dependencies = ["build_user_toolchain"]
+dependencies = ["copy_config_toml"]
 cwd = "../extern/rust"
 command = "python"
 args = ["x.py", "install", "rustfmt", "rustc", "library/std"]
+
+[tasks.dist_user_toolchain]
+workspace = false
+dependencies = ["copy_config_toml"]
+cwd = "../extern/rust"
+command = "python"
+args = ["x.py", "dist", "rustfmt", "rustc", "library/std"]


### PR DESCRIPTION
## Summary

Added toolchain distribution, this allows us to reduce compile time as we rarely update the rustc, and even if we update, I can use my PC to build the toolchain then continue fast development on the laptop.


### Related issue

Fixes #87 


## Changes
- Added toolchain distribution through CI.
- Modified parts of make files to allow usage of preinstalled toolchain.
- updated docs to reflect those.


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
