### PR TITLE
Filesystem refactors

### DIFF
--- a/book/src/userspace/programs.md
+++ b/book/src/userspace/programs.md
@@ -32,6 +32,22 @@ This is a basic shell, that can change directories, and execute programs.
 | `pwd` (internal) | Print working directory |
 | `exit` (internal) | Exit the shell, which will just cause another to come back up |
 | `ls` | List directory contents |
+| `tree` | List directory contents recursively |
 | `echo` | Write arguments to the standard output |
 | `cat` | Print 1 file on the standard output (no concat yet XD) |
 | `xxd` | Hexdump utility |
+| `keyboard` | Keyboard test program |
+| `mouse` | Mouse test program |
+
+## `graphics`
+Here we have simple graphics programs that will take control of the graphics controller from the kernel and thus
+will look like exiting from shell, upon exiting the program, the shell will come back up.
+
+### List of commands/Programs
+| Name | Description |
+| ---- | ----------- |
+| `graphics` | Simple graphics demo progam, it will display a red ball and it will bounce around the screen |
+| `video` | Video player, it will take a video in image zip format, that is a zip file with jpg images inside it, check [`tools/video_to_zip.sh`] for how to convert normal videos to this format. You can specify the fps upon creation (default is `30`), and specify it as will when running the program. |
+
+[`tools/video_to_zip.sh`]: https://github.com/Amjad50/Emerald/blob/master/tools/video_to_zip.sh
+

--- a/kernel/src/devices/pipe.rs
+++ b/kernel/src/devices/pipe.rs
@@ -4,7 +4,7 @@ use alloc::{collections::VecDeque, string::String, sync::Arc};
 use kernel_user_link::file::BlockingMode;
 
 use crate::{
-    fs::{self, FileAttributes, FileSystemError, INode},
+    fs::{self, FileAttributes, FileNode, FileSystemError},
     sync::spin::mutex::Mutex,
 };
 
@@ -31,15 +31,15 @@ pub fn create_pipe_pair() -> (fs::File, fs::File) {
         clones: AtomicUsize::new(1),
     });
 
-    let read_inode = INode::new_device(
+    let read_inode = FileNode::new_device(
         String::from("read_pipe"),
         FileAttributes::EMPTY,
-        Some(read_device),
+        read_device,
     );
-    let write_inode = INode::new_device(
+    let write_inode = FileNode::new_device(
         String::from("write_pipe"),
         FileAttributes::EMPTY,
-        Some(write_device),
+        write_device,
     );
     let read_file = fs::File::from_inode(
         read_inode,

--- a/kernel/src/fs/fat.rs
+++ b/kernel/src/fs/fat.rs
@@ -20,14 +20,26 @@ use super::{
 const DIRECTORY_ENTRY_SIZE: u32 = 32;
 
 fn file_attribute_from_fat(attributes: u8) -> FileAttributes {
-    FileAttributes {
-        read_only: attributes & attrs::READ_ONLY == attrs::READ_ONLY,
-        hidden: attributes & attrs::HIDDEN == attrs::HIDDEN,
-        system: attributes & attrs::SYSTEM == attrs::SYSTEM,
-        volume_label: attributes & attrs::VOLUME_ID == attrs::VOLUME_ID,
-        directory: attributes & attrs::DIRECTORY == attrs::DIRECTORY,
-        archive: attributes & attrs::ARCHIVE == attrs::ARCHIVE,
+    let mut file_attributes = FileAttributes::EMPTY;
+    if attributes & attrs::READ_ONLY == attrs::READ_ONLY {
+        file_attributes |= FileAttributes::READ_ONLY;
     }
+    if attributes & attrs::HIDDEN == attrs::HIDDEN {
+        file_attributes |= FileAttributes::HIDDEN;
+    }
+    if attributes & attrs::SYSTEM == attrs::SYSTEM {
+        file_attributes |= FileAttributes::SYSTEM;
+    }
+    if attributes & attrs::VOLUME_ID == attrs::VOLUME_ID {
+        file_attributes |= FileAttributes::VOLUME_LABEL;
+    }
+    if attributes & attrs::DIRECTORY == attrs::DIRECTORY {
+        file_attributes |= FileAttributes::DIRECTORY;
+    }
+    if attributes & attrs::ARCHIVE == attrs::ARCHIVE {
+        file_attributes |= FileAttributes::ARCHIVE;
+    }
+    file_attributes
 }
 
 #[derive(Debug)]

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -21,7 +21,7 @@ mod mbr;
 pub mod path;
 
 /// This is not used at all, just an indicator in [`Directory::fetch_entries`]
-pub(crate) const ANOTHER_FILESYSTEM_MAPPING_INODE_MAGIC: u64 = 0xf11356573E;
+pub(crate) const ANOTHER_FILESYSTEM_MAPPING_INODE_MAGIC: u64 = 0xf11356573e;
 
 static FILESYSTEM_MAPPING: Mutex<FileSystemMapping> = Mutex::new(FileSystemMapping {
     mappings: Vec::new(),

--- a/userspace/Makefile.toml
+++ b/userspace/Makefile.toml
@@ -52,4 +52,5 @@ args = ["-r", "${USER_OUTDIR}/echo",
               "${USER_OUTDIR}/mouse",
               "${USER_OUTDIR}/graphics",
               "${USER_OUTDIR}/video",
+              "${USER_OUTDIR}/tree",
               "${FILESYSTEM_PATH}/"]

--- a/userspace/shell/Cargo.toml
+++ b/userspace/shell/Cargo.toml
@@ -33,6 +33,10 @@ path = "src/keyboard.rs"
 name = "mouse"
 path = "src/mouse.rs"
 
+[[bin]]
+name = "tree"
+path = "src/tree.rs"
+
 [dependencies]
 colored = "2.1.0"
 emerald_runtime = { path = "../../libraries/emerald_runtime"}

--- a/userspace/shell/src/tree.rs
+++ b/userspace/shell/src/tree.rs
@@ -1,0 +1,142 @@
+//! Tree shell program
+//!
+//! Usage: tree [paths...]
+
+#![feature(io_error_more)]
+
+use std::{
+    path::Path,
+    process::{exit, ExitCode},
+};
+
+use colored::{control::SHOULD_COLORIZE, Colorize};
+
+struct Counter {
+    files: usize,
+    dirs: usize,
+}
+
+impl Counter {
+    fn new() -> Self {
+        Self { files: 0, dirs: 0 }
+    }
+
+    fn inc_file(&mut self) {
+        self.files += 1;
+    }
+
+    fn inc_dir(&mut self) {
+        self.dirs += 1;
+    }
+}
+
+fn tree<P: AsRef<Path>>(path: P, depth: Option<usize>, counter: &mut Counter) {
+    fn inner_tree(path: &Path, depth: usize, padding: &str, counter: &mut Counter) {
+        if depth == 0 {
+            return;
+        }
+
+        let entries = match path.read_dir() {
+            Ok(entries) => entries,
+            Err(e) => {
+                eprintln!("[!] error: {}", e);
+                return;
+            }
+        };
+
+        let entries = entries.filter_map(|e| e.ok()).collect::<Vec<_>>();
+
+        for (i, entry) in entries.iter().enumerate() {
+            let last = i == entries.len() - 1;
+            let is_dir = entry.metadata().unwrap().is_dir();
+            let name = entry
+                .file_name()
+                .into_string()
+                .unwrap_or_else(|_| String::from("<invalid>"));
+            if name == "." || name == ".." {
+                continue;
+            }
+            let name = if is_dir {
+                name.bold().blue()
+            } else {
+                name.normal()
+            };
+
+            println!("{}{}{}", padding, if last { "+-- " } else { "|-- " }, name);
+            if is_dir {
+                counter.inc_dir();
+                if last {
+                    inner_tree(
+                        &entry.path(),
+                        depth - 1,
+                        &format!("{}    ", padding),
+                        counter,
+                    );
+                } else {
+                    inner_tree(
+                        &entry.path(),
+                        depth - 1,
+                        &format!("{}|   ", padding),
+                        counter,
+                    );
+                }
+            } else {
+                counter.inc_file();
+            }
+        }
+    }
+
+    let path = path.as_ref();
+    let depth = depth.unwrap_or(usize::MAX);
+
+    if path.is_dir() {
+        counter.inc_dir();
+        println!("{}", path.display().to_string().bold().blue());
+        inner_tree(path, depth, "", counter);
+    } else {
+        counter.inc_file();
+        println!("{}", path.display().to_string().normal());
+    }
+}
+
+fn main() -> ExitCode {
+    SHOULD_COLORIZE.set_override(true);
+    let args = std::env::args().collect::<Vec<_>>();
+
+    let mut counter = Counter::new();
+
+    let mut paths = Vec::new();
+    let mut depth = None;
+
+    if args.len() < 2 {
+        paths.push(".");
+    }
+
+    let mut iter = args.iter().skip(1);
+
+    while let Some(arg) = iter.next() {
+        if arg == "-d" {
+            let arg = iter.next().unwrap_or_else(|| {
+                println!("missing argument for -d");
+                exit(1); // TODO: replace with ExitCode::FAILURE
+            });
+            depth = Some(arg.parse::<usize>().unwrap_or_else(|_| {
+                println!("invalid argument for -d");
+                exit(1); // TODO: replace with ExitCode::FAILURE
+            }));
+        } else if arg == "-h" {
+            println!("Usage: {} [-d <n>] [paths...]", args[0]);
+            return ExitCode::SUCCESS;
+        } else {
+            paths.push(arg);
+        }
+    }
+
+    for path in paths {
+        tree(path, depth, &mut counter);
+    }
+
+    println!("\n{} directories, {} files", counter.dirs, counter.files);
+
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
## Summary
Small refactoring work in `FileSystem`, this is kernel internal, so nothing is visible to the outside.

Also added `tree` program and implemented sorting for `ls`

### Related issue
none


## Changes
- Used callback to read `directories` and thus reduce load on the disk and unneeded reads. Sadly using iterator and such is a bit annoying (not sure if even possible with rust lifetimes and object safety)
- Changed `INode` to `Node` that is an enum of `DirectoryNode` and `FileNode`. Thus, using type system for safety.
- Changed `FileAttribute` to use `u8` instead of bools
- Fixed an issue when reading directories, previously we weren't taking account other `filesystem mappings`, i.e.
if for example we have `/` and `/devices` as 2 filesystems, before this PR, doing `ls /` will not show `/devices` since its in another filesystem. We fixed it so that its getting added when listing directories so now `ls /` will display `/devices`
- Used sorting for `ls` based on directories first, then by name (non configurable)
- Added `tree` shell program


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
