### PR TITLE
Kernel+User: implement backspace for shell

### DIFF
--- a/kernel/src/io/console/vga_text.rs
+++ b/kernel/src/io/console/vga_text.rs
@@ -101,6 +101,21 @@ impl VideoConsole for VgaText {
         self.fix_after_advance();
     }
 
+    fn backspace(&mut self) {
+        if self.pos.0 == 0 {
+            if self.pos.1 == 0 {
+                return;
+            }
+            self.pos.0 = self.width - 1;
+            self.pos.1 -= 1;
+        } else {
+            self.pos.0 -= 1;
+        }
+        let i = self.get_arr_pos(self.pos);
+        self.memory[i] = b' ';
+        self.memory[i + 1] = self.attrib;
+    }
+
     fn set_attrib(&mut self, attrib: VideoConsoleAttribute) {
         let to_vga_color = |color: u8| {
             let mappings = &[

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -44,10 +44,19 @@ fn main() {
                 }
                 core::hint::spin_loop();
             }
+            if buf[0] == 0x08 {
+                // backspace
+                if line_buffer.pop().is_none() {
+                    // nothing to delete
+                    continue;
+                }
+            } else {
+                line_buffer.push(buf[0]);
+            }
+
             // also output to our stdout
             std::io::stdout().write_all(&buf).unwrap();
             std::io::stdout().flush().unwrap();
-            line_buffer.push(buf[0]);
 
             if buf[0] == b'\n' {
                 if child_stdin.write_all(&line_buffer).is_err() {


### PR DESCRIPTION
Its kinda ugly solution, that's why I didn't do it from the beginning, but now we can edit commands easily


## Summary
Added support for backspace in the shell, previously, we couldn't delete character we already typed. This was fixed in this PR

### Related issue
Its a known issue, but no open issue were on it.

## Changes
- Fixed issue, backspace not working in the `shell`.


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
