### PR TITLE
Add write support for Filesystem and FAT specifically

### DIFF
--- a/book/src/kernel/filesystem/fat.md
+++ b/book/src/kernel/filesystem/fat.md
@@ -6,6 +6,9 @@
 
 The FAT filesystem is a simple filesystem that is widely used in many devices, such as USB drives, SD cards, and floppy disks.
 
-In this kernel, we have FAT12, FAT16, and FAT32 support. Along with long file names (LFN) support.
-
-We don't have write support yet, but we can read files and directories.
+In this kernel, we have support for:
+- FAT12
+- FAT16
+- FAT32 
+- Long file names (LFN).
+- reading and writing files, changing file size, and creating files and directories.

--- a/book/src/kernel/filesystem/index.md
+++ b/book/src/kernel/filesystem/index.md
@@ -21,18 +21,34 @@ For example, currently we have the following mappings:
 ```
 
 When you open a path, it will find the best mapping, i.e. the longest prefix that matches the path.
-Then will use the resulting `Filesystem` manager to open the file.
+Then will use the resulting [`Filesystem`][kernel_fs_trait] manager to open the file.
 
-For example, if you open the path `/devices/console`, it will use the `Devices` manager to open the file `/console`.
+For example, if you open the path `/devices/console`, it will use the `Devices` filesystem manager to open the file `/console`.
 
-## INode
+### Filesystem trait
 
-> See [INode][kernel_inode]
+The "manager" here is an implementor of the [`Filesystem`][kernel_fs_trait] trait, which is a simple interface that controls all
+the filesystem operations.
 
-The `Filesystem` will give us an `INode` when we open a directory or a file, and this `INode` gives information
-about the file, as well as the `device` that it may contain.
+Operations supported are:
+- `open_root` - Open the root directory, this is the entry point when treversing the filesystem.
+- `read_dir` - Read the directory entries from a [`DirectoryNode`][kernel_fs_dirnode].
+- `create_node` - Create a new file or directory inside a [`DirectoryNode`][kernel_fs_dirnode].
+- `read_file` - Read the file contents from a [`FileNode`][kernel_fs_filenode].
+- `write_file` - Write the file contents to a [`FileNode`][kernel_fs_filenode].
+- `close_file` - Send a message that we are closing the file, if you notice, we don't have `open_file`, but instead, the user can 
+  treverse the filesystem with `open_root` and `read_dir` until the file node is found, then it can be used directly. This function
+  is used to alert the filesystem to clean up any resources that it might have allocated for this file.
+- `set_file_size` - Set the file size to a custom value, this is similar to `truncate` in Unix systems, `write_file`, will increase
+  the file size if needed.
 
-> I'm calling `INode` even though [FAT] doesn't have this concept, but I'm using it to represent the file information.
+## Node
+
+> See [Node][kernel_fs_node]
+
+The `Filesystem` will give us an `Node` when we open a directory or a file, and this `Node` can be either [`FileNode`][kernel_fs_filenode] or [`DirectoryNode`][kernel_fs_dirnode]
+
+> I'm calling `Node` even though [FAT] doesn't have this concept, but I'm using it to represent the file information.
 
 ## Partition tables
 
@@ -43,6 +59,6 @@ Currently we only support the [MBR][kernel_mbr] partition table, and we can only
 > See [Devices][kernel_devices_map]
 
 This is a basic dictionary that maps a device name, to a `Arc<dyn Device>`. Then, when its opened, the device clone is
-returned in a special `INode`.
+returned in a special [`FileNode`][kernel_fs_filenode], so we can act upon it as a file.
 
 [FAT]: ./fat.md

--- a/book/src/links.md.template
+++ b/book/src/links.md.template
@@ -14,7 +14,10 @@
 [uart]: {ROOT_PATH}docs/kernel/io/uart
 [console]: {ROOT_PATH}docs/kernel/io/console
 [kernel_filesystem]: {ROOT_PATH}docs/kernel/fs
-[kernel_inode]: {ROOT_PATH}docs/kernel/fs/struct.INode.html
+[kernel_fs_node]: {ROOT_PATH}docs/kernel/fs/enum.Node.html
+[kernel_fs_filenode]: {ROOT_PATH}docs/kernel/fs/struct.FileNode.html
+[kernel_fs_dirnode]: {ROOT_PATH}docs/kernel/fs/struct.DirectoryNode.html
+[kernel_fs_trait]: {ROOT_PATH}docs/kernel/fs/trait.FileSystem.html
 [kernel_mbr]: {ROOT_PATH}docs/kernel/fs/mbr
 [kernel_devices_map]: {ROOT_PATH}docs/kernel/devices/struct.Devices.html
 [kernel_fat]: {ROOT_PATH}docs/kernel/fs/fat

--- a/kernel/src/devices/ide.rs
+++ b/kernel/src/devices/ide.rs
@@ -160,6 +160,7 @@ mod ata {
     pub const COMMAND_IDENTIFY: u8 = 0xEC;
     pub const COMMAND_PACKET_IDENTIFY: u8 = 0xA1;
     pub const COMMAND_READ_SECTORS: u8 = 0x20;
+    pub const COMMAND_WRITE_SECTORS: u8 = 0x30;
     pub const COMMAND_DEVICE_RESET: u8 = 0x08;
     pub const COMMAND_PACKET: u8 = 0xA0;
 
@@ -277,6 +278,32 @@ impl IdeIo {
 
         Ok(())
     }
+
+    pub fn write_data_block(&self, data: &[u8]) -> Result<(), u8> {
+        self.wait_until_free();
+
+        if self.read_status() & ata::STATUS_ERR != 0 {
+            // error
+            return Err(self.read_error());
+        }
+
+        // write data
+        for i in 0..data.len() / 2 {
+            let word = (data[i * 2] as u16) | ((data[i * 2 + 1] as u16) << 8);
+
+            self.write_data(word);
+
+            // TODO: maybe not best to check on every write, but when reading multiple sectors
+            if self.read_status() & ata::STATUS_BUSY != 0 {
+                self.wait_until_free();
+            }
+        }
+
+        // TODO: replace with error
+        assert!(self.read_status() & ata::STATUS_DATA_REQUEST == 0);
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -334,13 +361,22 @@ impl AtaCommand {
         io_port.write_command_block(ata::COMMAND, self.command);
     }
 
-    pub fn execute(&self, io_port: &IdeIo, data: &mut [u8]) -> Result<(), u8> {
+    pub fn execute_read(&self, io_port: &IdeIo, data: &mut [u8]) -> Result<(), u8> {
         // must be even since we are receiving 16 bit words
         assert!(data.len() % 2 == 0);
         io_port.wait_until_can_command()?;
         self.write(io_port);
 
         io_port.read_data_block(data)
+    }
+
+    pub fn execute_write(&self, io_port: &IdeIo, data: &[u8]) -> Result<(), u8> {
+        // must be even since we are sending 16 bit words
+        assert!(data.len() % 2 == 0);
+        io_port.wait_until_can_command()?;
+        self.write(io_port);
+
+        io_port.write_data_block(data)
     }
 }
 
@@ -709,6 +745,29 @@ impl IdeDevice {
                 .map_err(IdeError::DeviceError)
         }
     }
+
+    pub fn write_sync(&self, start_sector: u64, data: &[u8]) -> Result<(), IdeError> {
+        let sector_size = self.sector_size as u64;
+        let buffer_len = data.len() as u64;
+
+        if buffer_len % sector_size != 0 {
+            return Err(IdeError::UnalignedSize);
+        }
+        if start_sector >= self.number_of_sectors {
+            return Err(IdeError::BoundsExceeded);
+        }
+
+        let number_of_sectors = buffer_len / sector_size;
+
+        if self.device_type == IdeDeviceType::Ata {
+            self.device_impl
+                .lock()
+                .write_sync_ata(start_sector, number_of_sectors, data)
+                .map_err(IdeError::DeviceError)
+        } else {
+            todo!("write_sync for ATAPI");
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -736,7 +795,7 @@ impl IdeDeviceImpl {
 
         let mut device_type = IdeDeviceType::Ata;
 
-        if let Err(err) = command.execute(&io, &mut identify_data) {
+        if let Err(err) = command.execute_read(&io, &mut identify_data) {
             assert!(err & ata::ERROR_ABORTED != 0);
             let lbalo = io.read_command_block(ata::LBA_LO);
             let lbamid = io.read_command_block(ata::LBA_MID);
@@ -766,7 +825,7 @@ impl IdeDeviceImpl {
             // here we know we are running an ATAPI device
             let command = AtaCommand::new(ata::COMMAND_PACKET_IDENTIFY)
                 .with_second_drive(second_device_select);
-            if let Err(err) = command.execute(&io, &mut identify_data) {
+            if let Err(err) = command.execute_read(&io, &mut identify_data) {
                 println!("Error: unknown ATAPI device aborted: Err={err:02x}",);
                 return None;
             }
@@ -857,7 +916,7 @@ impl IdeDeviceImpl {
             .with_sector_count(len_sectors as u16)
             .with_second_drive(self.second_device_select);
 
-        command.execute(&self.io, data)
+        command.execute_read(&self.io, data)
     }
 
     fn read_sync_atapi(
@@ -878,6 +937,22 @@ impl IdeDeviceImpl {
             .push_param(0); // control
 
         command.execute(&self.io, data)
+    }
+
+    fn write_sync_ata(
+        &mut self,
+        start_sector: u64,
+        len_sectors: u64,
+        data: &[u8],
+    ) -> Result<(), u8> {
+        assert!(len_sectors <= u16::MAX as u64);
+        // the buffer is enough to hold the data (see write_sync)
+        let command = AtaCommand::new(ata::COMMAND_WRITE_SECTORS)
+            .with_lba(start_sector)
+            .with_sector_count(len_sectors as u16)
+            .with_second_drive(self.second_device_select);
+
+        command.execute_write(&self.io, data)
     }
 
     fn interrupt(&mut self) {}

--- a/kernel/src/devices/mod.rs
+++ b/kernel/src/devices/mod.rs
@@ -58,7 +58,7 @@ pub trait Device: Sync + Send + fmt::Debug {
 
 impl FileSystem for RwLock<Devices> {
     fn open_root(&self) -> Result<DirectoryNode, FileSystemError> {
-        Ok(DirectoryNode::new(
+        Ok(DirectoryNode::without_parent(
             String::from("/"),
             FileAttributes::DIRECTORY,
             DEVICES_FILESYSTEM_ROOT_INODE_MAGIC,

--- a/kernel/src/fs/fat.rs
+++ b/kernel/src/fs/fat.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use super::{
-    AccessHelper, DirTreverse, DirectoryNode, FileAttributes, FileNode, FileSystem,
+    AccessHelper, BaseNode, DirTreverse, DirectoryNode, FileAttributes, FileNode, FileSystem,
     FileSystemError, Node,
 };
 
@@ -1524,7 +1524,7 @@ impl FatFilesystem {
 
     fn update_directory_entry(
         &mut self,
-        inode: &FileNode,
+        inode: &BaseNode,
         mut update: impl FnMut(&mut DirectoryEntryNormal),
     ) -> Result<(), FileSystemError> {
         let mut sector = self.read_sectors_no_cache(inode.parent_dir_sector() as u32, 1)?;

--- a/kernel/src/fs/fat.rs
+++ b/kernel/src/fs/fat.rs
@@ -93,8 +93,8 @@ fn create_dir_entries(
     }
     assert!(filename.len() <= 8);
 
-    for i in 0..8 {
-        short_name[i] = if i < filename.len() {
+    for (i, c) in short_name.iter_mut().enumerate().take(8) {
+        *c = if i < filename.len() {
             filename.as_bytes()[i].to_ascii_uppercase()
         } else {
             b' '
@@ -1616,7 +1616,7 @@ impl FatFilesystem {
                 _nt_reserved: 0,
                 ..normal_entry
             };
-            dot_entry.short_name[0] = '.' as u8;
+            dot_entry.short_name[0] = b'.';
             let parent_cluster = parent_inode.start_cluster() as u32;
             let mut dot_dot_entry = DirectoryEntryNormal {
                 short_name: [0x20; 11],
@@ -1632,15 +1632,15 @@ impl FatFilesystem {
                 last_modification_date: 0,
                 file_size: 0,
             };
-            dot_dot_entry.short_name[0] = '.' as u8;
-            dot_dot_entry.short_name[1] = '.' as u8;
+            dot_dot_entry.short_name[0] = b'.';
+            dot_dot_entry.short_name[1] = b'.';
 
             let dir_node = match node {
                 Node::Directory(ref dir) => dir,
                 _ => unreachable!(),
             };
 
-            let mut dir_iter = self.open_dir_inode(&dir_node)?;
+            let mut dir_iter = self.open_dir_inode(dir_node)?;
             let dot_node = dir_iter.add_entry(dot_entry, Vec::new())?;
             let dot_dot_node = dir_iter.add_entry(dot_dot_entry, Vec::new())?;
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -911,6 +911,10 @@ impl File {
         self.position
     }
 
+    pub fn set_size(&mut self, size: u64) -> Result<(), FileSystemError> {
+        self.filesystem.set_file_size(&mut self.inode, size)
+    }
+
     /// This is a move verbose method than `Clone::clone`, as I want it to be
     /// more explicit to the user that this is not a normal `clone` operation.
     pub fn clone_inherit(&self) -> Self {

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -203,20 +203,6 @@ impl FileNode {
     }
 }
 
-impl ops::Deref for FileNode {
-    type Target = BaseNode;
-
-    fn deref(&self) -> &Self::Target {
-        &self.base
-    }
-}
-
-impl ops::DerefMut for FileNode {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.base
-    }
-}
-
 impl Drop for FileNode {
     fn drop(&mut self) {
         if let Some(device) = self.device.take() {
@@ -252,14 +238,6 @@ impl DirectoryNode {
                 parent_dir_index,
             },
         }
-    }
-}
-
-impl ops::Deref for DirectoryNode {
-    type Target = BaseNode;
-
-    fn deref(&self) -> &Self::Target {
-        &self.base
     }
 }
 
@@ -367,6 +345,54 @@ impl Node {
         }
 
         Ok(())
+    }
+}
+
+impl ops::Deref for FileNode {
+    type Target = BaseNode;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl ops::DerefMut for FileNode {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
+impl ops::Deref for DirectoryNode {
+    type Target = BaseNode;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl ops::DerefMut for DirectoryNode {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
+impl ops::Deref for Node {
+    type Target = BaseNode;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::File(file) => file,
+            Self::Directory(dir) => dir,
+        }
+    }
+}
+
+impl ops::DerefMut for Node {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::File(file) => file,
+            Self::Directory(dir) => dir,
+        }
     }
 }
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -905,9 +905,6 @@ impl File {
     }
 
     pub fn seek(&mut self, position: u64) -> Result<(), FileSystemError> {
-        if position > self.inode.size() {
-            return Err(FileSystemError::InvalidOffset);
-        }
         self.position = position;
         Ok(())
     }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -360,8 +360,8 @@ impl Node {
 // use to help implement the filesystem and improve performance
 #[derive(Debug, Default)]
 pub struct AccessHelper {
-    previous_position: u64,
     current_cluster: u64,
+    cluster_index: u64,
 }
 
 pub enum DirTreverse {
@@ -410,7 +410,7 @@ pub trait FileSystem: Send + Sync {
     fn close_file(
         &self,
         _inode: &FileNode,
-        _access_helper: &mut AccessHelper,
+        _access_helper: AccessHelper,
     ) -> Result<(), FileSystemError> {
         Ok(())
     }
@@ -939,7 +939,7 @@ impl File {
 impl Drop for File {
     fn drop(&mut self) {
         self.filesystem
-            .close_file(&self.inode, &mut self.access_helper)
+            .close_file(&self.inode, core::mem::take(&mut self.access_helper))
             .expect("Failed to close file");
     }
 }

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -62,6 +62,7 @@ impl From<FileSystemError> for SyscallError {
             FileSystemError::EndOfFile => SyscallError::EndOfFile,
             FileSystemError::IsNotDirectory => SyscallError::IsNotDirectory,
             FileSystemError::IsDirectory => SyscallError::IsDirectory,
+            FileSystemError::FileAlreadyExists => todo!(),
             FileSystemError::DeviceNotFound => todo!(),
             FileSystemError::BufferNotLargeEnough(_) => SyscallError::BufferTooSmall,
             FileSystemError::DiskReadError { .. }

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -766,10 +766,9 @@ fn sys_seek(all_state: &mut InterruptAllSavedState) -> SyscallResult {
                 .try_into()
                 .map_err(|_| SyscallError::InvalidOffset)?,
             SeekWhence::Current => {
-                let current: i64 = file
-                    .current_position()
-                    .try_into()
-                    .map_err(|_| SyscallError::InvalidOffset)?;
+                let current: i64 = file.current_position().try_into().expect(
+                    "current position should be positive and would be less than i64 bit in size",
+                );
                 current
                     .checked_add(seek.offset)
                     .ok_or(SyscallError::InvalidOffset)?
@@ -777,11 +776,9 @@ fn sys_seek(all_state: &mut InterruptAllSavedState) -> SyscallResult {
                     .map_err(|_| SyscallError::InvalidOffset)?
             }
             SeekWhence::End => {
-                // TODO: add support for seek more than the file size
-                if seek.offset > 0 {
-                    return Err(SyscallError::InvalidOffset);
-                }
-                let end: i64 = size.try_into().map_err(|_| SyscallError::InvalidOffset)?;
+                let end: i64 = size
+                    .try_into()
+                    .expect("size should be positive and would be less than i64 bit in size");
                 end.checked_add(seek.offset)
                     .ok_or(SyscallError::InvalidOffset)?
                     .try_into()
@@ -791,7 +788,7 @@ fn sys_seek(all_state: &mut InterruptAllSavedState) -> SyscallResult {
 
         file.seek(new_location)?;
 
-        Ok(new_location)
+        Ok::<_, SyscallError>(new_location)
     })?;
 
     SyscallResult::Ok(new_position)

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -58,7 +58,7 @@ impl From<FileSystemError> for SyscallError {
             FileSystemError::InvalidPath => SyscallError::CouldNotOpenFile,
             FileSystemError::FileNotFound => SyscallError::FileNotFound,
             FileSystemError::ReadNotSupported => SyscallError::CouldNotReadFromFile,
-            FileSystemError::WriteNotSupported => SyscallError::CouldNotWriteToFile,
+            FileSystemError::WriteNotSupported | FileSystemError::CouldNotSetFileLength => SyscallError::CouldNotWriteToFile,
             FileSystemError::EndOfFile => SyscallError::EndOfFile,
             FileSystemError::IsNotDirectory => SyscallError::IsNotDirectory,
             FileSystemError::IsDirectory => SyscallError::IsDirectory,


### PR DESCRIPTION
## Summary
Added support for `write` in `FAT` and creating new files in filesystems.

### Related issue

Fixes #31 
Fixes #79 


## Changes
- Added support for `write` in the FAT filesystem.
- Added a way to set the filesize for any file.
- Added a way to create a `Node` in a directory.


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
