### PR TITLE
File open permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,40 +42,38 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'false'
-      - name: Get changed files in `rust` submodule
-        id: rust-changes
-        uses: tj-actions/changed-files@v42
-        with:
-          files: 'extern/rust'
+
+      - name: Get submodule hash
+        id: submodule-hash
+        run: echo "hash=$(git ls-tree HEAD extern/rust | awk '{print $3}')" >> $GITHUB_OUTPUT
       
       - name: Restore cached rust build
         id: cache-os-rust-restore
-        if: steps.rust-changes.outputs.any_changed != 'true'
         uses: actions/cache/restore@v4
         with:
-          key: rust-build-toolchain
+          key: rust-${{ steps.submodule-hash.outputs.hash }}
           path: /tmp/dist
   
       # run after this if something changed, otherwise skip all
       - uses: actions-rs/toolchain@v1
-        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true' || steps.rust-changes.outputs.any_changed == 'true'
+        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true'
         with:
           toolchain: nightly-2024-01-04
           components: rust-src
       - name: Get cargo-make
-        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true' || steps.rust-changes.outputs.any_changed == 'true'
+        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true'
         uses: davidB/rust-cargo-make@v1
       
       # Fetch only top level submodules without recursive
       # building the toolchain will automatically fetch the children of `rust`
       # 100 so that we can get at least a single `upstream` commit, for llvm-ci cache to work
       - name: submodule fetch bare
-        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true' || steps.rust-changes.outputs.any_changed == 'true'
+        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true'
         run: git submodule update --init --depth 100
       - run: cargo make toolchain_dist
-        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true' || steps.rust-changes.outputs.any_changed == 'true'
+        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true'
       - name: Copy dist to tmp
-        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true' || steps.rust-changes.outputs.any_changed == 'true'
+        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/dist
           cp ./extern/rust/build/dist/rustc-1*linux*.xz ./extern/rust/build/dist/rust-std*.xz ./extern/rust/build/dist/rustfmt*.xz /tmp/dist
@@ -83,7 +81,7 @@ jobs:
       - name: Save cache toolchain
         id: cache-os-rust-save
         uses: actions/cache/save@v4
-        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true' || steps.rust-changes.outputs.any_changed == 'true'
+        if: steps.cache-os-rust-restore.outputs.cache-hit != 'true'
         with:
           path: /tmp/dist
           key: ${{ steps.cache-os-rust-restore.outputs.cache-primary-key }}
@@ -106,12 +104,17 @@ jobs:
           toolchain: nightly-2024-01-04
           components: rust-src
       - uses: davidB/rust-cargo-make@v1
+
+      - name: Get submodule hash
+        id: submodule-hash
+        run: echo "hash=$(git ls-tree HEAD extern/rust | awk '{print $3}')" >> $GITHUB_OUTPUT
+
       - name: Restore cached rust build
         id: cache-os-rust-restore
         uses: actions/cache/restore@v4
         with:
           path: /tmp/dist
-          key: rust-build-toolchain
+          key: rust-${{ steps.submodule-hash.outputs.hash }}
           fail-on-cache-miss: true
       - name: install toolchain
         run: bash tools/install_toolchain_and_link.sh /tmp/dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "emerald_kernel_user_link"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "emerald_std"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "compiler_builtins",
  "emerald_kernel_user_link",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "emerald_kernel_user_link"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/book/src/kernel/filesystem/index.md
+++ b/book/src/kernel/filesystem/index.md
@@ -7,9 +7,20 @@
 In this kernel, the filesystem is implemented by several layers, and components.
 
 When you try to open a file path, the `filesystem` will look for the best entity that contains this path.
-And this is achieved by the **mapping** system.
+And this is achieved by the [mapping](#mapping) system.
 
-Check [FAT] for more information about the FAT filesystem.
+Check [FAT] for more information about the FAT filesystem specifically.
+
+Then, when you open a file, you can specify several flags (implemented in [`OpenOptions`][fs_open_options]):
+- `read` - Open the file for reading.
+- `write` - Open the file for writing.
+- `create` - Create the file if it doesn't exist.
+- `create_new` - Fail if the file exists.
+- `truncate` - Truncate the file if it exists.
+- `append` (implicit `write`) - Append to the file if it exists.
+
+With these, you can create new files and choose which mode to open them with. Of course the filesystem may refuse to create the file if the
+operation is not supported, such as with `/devices` directory mappings.
 
 ## Mapping
 

--- a/book/src/links.md.template
+++ b/book/src/links.md.template
@@ -48,3 +48,4 @@
 [clocks]: {ROOT_PATH}docs/kernel/devices/clock
 [vga]: {ROOT_PATH}docs/kernel/graphics/vga
 [framebufferinfo]: {ROOT_PATH}docs/kernel/graphics/vga/struct.FrameBufferInfo.html
+[fs_open_options]: {ROOT_PATH}docs/emerald_kernel_user_link/file/struct.OpenOptions.html

--- a/book/src/userspace/programs.md
+++ b/book/src/userspace/programs.md
@@ -24,6 +24,15 @@ This is a temporary behavior (maybe?), but we still need to improve file operati
 
 This is a basic shell, that can change directories, and execute programs.
 
+It also support output redirect (no piping between processes yet), so you can do something like:
+```sh
+ls > file.txt
+```
+or even append to a file:
+```sh
+ls >> file.txt
+```
+
 ### List of commands/programs
 
 | Name | Description |
@@ -31,6 +40,7 @@ This is a basic shell, that can change directories, and execute programs.
 | `cd` (internal) | Change directory |
 | `pwd` (internal) | Print working directory |
 | `exit` (internal) | Exit the shell, which will just cause another to come back up |
+| `touch` (internal) | Create a file, if not present |
 | `ls` | List directory contents |
 | `tree` | List directory contents recursively |
 | `echo` | Write arguments to the standard output |

--- a/kernel/src/devices/pipe.rs
+++ b/kernel/src/devices/pipe.rs
@@ -4,7 +4,7 @@ use alloc::{collections::VecDeque, string::String, sync::Arc};
 use kernel_user_link::file::BlockingMode;
 
 use crate::{
-    fs::{self, FileAttributes, FileNode, FileSystemError},
+    fs::{self, FileAccess, FileAttributes, FileNode, FileSystemError},
     sync::spin::mutex::Mutex,
 };
 
@@ -47,6 +47,7 @@ pub fn create_pipe_pair() -> (fs::File, fs::File) {
         fs::empty_filesystem(),
         0,
         BlockingMode::Block(1),
+        FileAccess::READ,
     )
     .expect("This is a file, shouldn't fail");
     // no blocking for write
@@ -56,6 +57,7 @@ pub fn create_pipe_pair() -> (fs::File, fs::File) {
         fs::empty_filesystem(),
         0,
         BlockingMode::None,
+        FileAccess::WRITE,
     )
     .expect("This is a file, shouldn't fail");
 

--- a/kernel/src/fs/fat.rs
+++ b/kernel/src/fs/fat.rs
@@ -910,7 +910,7 @@ impl DirectoryIterator<'_> {
                     running_free = 0;
                     first_free = None;
                     if !entry.is_long() && entry.as_normal().short_name == new_entry_short_name {
-                        return Err(FileSystemError::FileAlreadyExists);
+                        return Err(FileSystemError::AlreadyExists);
                     }
                 }
             }
@@ -925,7 +925,7 @@ impl DirectoryIterator<'_> {
                     DirectoryEntryState::Used => {
                         if !entry.is_long() && entry.as_normal().short_name == new_entry_short_name
                         {
-                            return Err(FileSystemError::FileAlreadyExists);
+                            return Err(FileSystemError::AlreadyExists);
                         }
                     }
                     _ => {}

--- a/kernel/src/fs/fat.rs
+++ b/kernel/src/fs/fat.rs
@@ -1766,12 +1766,13 @@ impl FatFilesystem {
 
             if current_size_in_clusters > new_size_in_clusters {
                 // deleting old clusters
-                let to_delete = current_size_in_clusters - new_size_in_clusters;
+                let mut to_delete = current_size_in_clusters - new_size_in_clusters;
                 let mut clusters = Vec::with_capacity(to_delete as usize);
 
                 if new_size_in_clusters == 0 {
                     // delete the first one
                     clusters.push(current_cluster);
+                    to_delete -= 1;
                 }
 
                 for _ in 0..to_delete {
@@ -1797,6 +1798,9 @@ impl FatFilesystem {
                         entry.first_cluster_hi = 0;
                         entry.first_cluster_lo = 0;
                     })?;
+                } else {
+                    // mark the current cluster as last
+                    self.fat.write_fat_entry(last_cluster, FatEntry::EndOfChain);
                 }
             } else {
                 // adding new clusters
@@ -1836,9 +1840,6 @@ impl FatFilesystem {
                     last_cluster = new_cluster;
                 }
             }
-
-            // mark the current cluster as last
-            self.fat.write_fat_entry(last_cluster, FatEntry::EndOfChain);
         }
 
         inode.set_size(size);

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -601,7 +601,7 @@ pub enum FileSystemError {
     CouldNotSetFileLength,
     EndOfFile,
     BufferNotLargeEnough(usize),
-    FileAlreadyExists,
+    AlreadyExists,
 }
 
 fn get_mapping(path: &Path) -> Result<(&Path, Arc<dyn FileSystem>), FileSystemError> {
@@ -829,7 +829,7 @@ impl File {
         let (mut node, filesystem) = match open_inode(path.as_ref()) {
             Ok((filesystem, inode)) => {
                 if open_options.is_create_new() {
-                    return Err(FileSystemError::FileAlreadyExists);
+                    return Err(FileSystemError::AlreadyExists);
                 }
 
                 (inode.into_file()?, filesystem)

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -1,7 +1,7 @@
 use core::ops;
 
 use alloc::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
-use kernel_user_link::file::{BlockingMode, DirEntry, FileStat, FileType};
+use kernel_user_link::file::{BlockingMode, DirEntry, FileStat, FileType, OpenOptions};
 
 use crate::{
     devices::{
@@ -745,6 +745,46 @@ pub(crate) fn open_inode<P: AsRef<Path>>(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileAccess {
+    read: bool,
+    write: bool,
+}
+
+impl FileAccess {
+    pub const READ: Self = Self {
+        read: true,
+        write: false,
+    };
+    pub const WRITE: Self = Self {
+        read: false,
+        write: true,
+    };
+
+    fn new(read: bool, write: bool) -> Self {
+        Self { read, write }
+    }
+
+    fn is_read(&self) -> bool {
+        self.read
+    }
+
+    fn is_write(&self) -> bool {
+        self.write
+    }
+}
+
+impl ops::BitOr for FileAccess {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self {
+            read: self.read || rhs.read,
+            write: self.write || rhs.write,
+        }
+    }
+}
+
 /// A handle to a file, it has the inode which controls the properties of the node in the filesystem
 pub struct File {
     filesystem: Arc<dyn FileSystem>,
@@ -754,6 +794,7 @@ pub struct File {
     is_terminal: bool,
     blocking_mode: BlockingMode,
     access_helper: AccessHelper,
+    file_access: FileAccess,
 }
 
 /// A handle to a directory, it has the inode which controls the properties of the node in the filesystem
@@ -777,16 +818,62 @@ pub enum FilesystemNode {
 #[allow(dead_code)]
 impl File {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, FileSystemError> {
-        Self::open_blocking(path, BlockingMode::None)
+        Self::open_blocking(path, BlockingMode::None, OpenOptions::default())
     }
 
     pub fn open_blocking<P: AsRef<Path>>(
         path: P,
         blocking_mode: BlockingMode,
+        open_options: OpenOptions,
     ) -> Result<Self, FileSystemError> {
-        let (filesystem, inode) = open_inode(path.as_ref())?;
+        let (mut node, filesystem) = match open_inode(path.as_ref()) {
+            Ok((filesystem, inode)) => {
+                if open_options.is_create_new() {
+                    return Err(FileSystemError::FileAlreadyExists);
+                }
 
-        Self::from_inode(inode.into_file()?, path, filesystem, 0, blocking_mode)
+                (inode.into_file()?, filesystem)
+            }
+            Err(FileSystemError::FileNotFound)
+                if open_options.is_create() || open_options.is_create_new() =>
+            {
+                let path = path.as_ref();
+                let (filesystem, parent_inode) = open_inode(path.parent().unwrap())?;
+                let filename = path.file_name().unwrap();
+                if filename == "." || filename == ".." || filename == "/" {
+                    return Err(FileSystemError::InvalidPath);
+                }
+                let node = filesystem.create_node(
+                    &parent_inode.into_dir()?,
+                    filename,
+                    FileAttributes::EMPTY,
+                )?;
+                (
+                    node.into_file()
+                        .expect("This should be a valid file, we created it"),
+                    filesystem,
+                )
+            }
+            Err(e) => return Err(e),
+        };
+
+        if open_options.is_truncate() {
+            if open_options.is_write() {
+                filesystem.set_file_size(&mut node, 0)?;
+            } else {
+                return Err(FileSystemError::WriteNotSupported);
+            }
+        }
+
+        let pos = if open_options.is_append() {
+            node.size()
+        } else {
+            0
+        };
+
+        let access = FileAccess::new(open_options.is_read(), open_options.is_write());
+
+        Self::from_inode(node, path, filesystem, pos, blocking_mode, access)
     }
 
     pub fn from_inode<P: AsRef<Path>>(
@@ -795,6 +882,7 @@ impl File {
         filesystem: Arc<dyn FileSystem>,
         position: u64,
         blocking_mode: BlockingMode,
+        file_access: FileAccess,
     ) -> Result<Self, FileSystemError> {
         Ok(Self {
             filesystem,
@@ -804,10 +892,15 @@ impl File {
             is_terminal: false,
             blocking_mode,
             access_helper: AccessHelper::default(),
+            file_access,
         })
     }
 
     pub fn read(&mut self, buf: &mut [u8]) -> Result<u64, FileSystemError> {
+        if !self.file_access.is_read() {
+            return Err(FileSystemError::ReadNotSupported);
+        }
+
         let count = match self.blocking_mode {
             BlockingMode::None => self.filesystem.read_file(
                 &self.inode,
@@ -894,6 +987,10 @@ impl File {
     }
 
     pub fn write(&mut self, buf: &[u8]) -> Result<u64, FileSystemError> {
+        if !self.file_access.is_write() {
+            return Err(FileSystemError::WriteNotSupported);
+        }
+
         let written = self.filesystem.write_file(
             &mut self.inode,
             self.position,
@@ -959,6 +1056,10 @@ impl File {
     }
 
     pub fn set_size(&mut self, size: u64) -> Result<(), FileSystemError> {
+        if !self.file_access.is_write() {
+            return Err(FileSystemError::WriteNotSupported);
+        }
+
         self.filesystem.set_file_size(&mut self.inode, size)
     }
 
@@ -973,6 +1074,7 @@ impl File {
             is_terminal: self.is_terminal,
             blocking_mode: self.blocking_mode,
             access_helper: AccessHelper::default(),
+            file_access: self.file_access,
         };
 
         // inform the device of a clone operation
@@ -1060,7 +1162,23 @@ impl Directory {
     ) -> Result<FilesystemNode, FileSystemError> {
         let node = self.filesystem.create_node(&self.inode, name, attributes)?;
 
-        FilesystemNode::from_node(self.path.join(name), node, self.filesystem.clone())
+        let path = self.path.join(name);
+
+        match node {
+            Node::File(file) => Ok(File::from_inode(
+                file,
+                path,
+                self.filesystem.clone(),
+                0,
+                BlockingMode::None,
+                // TODO: for now, set it as readable and writable, find a better way to handle that
+                FileAccess::READ | FileAccess::WRITE,
+            )?
+            .into()),
+            Node::Directory(directory) => {
+                Ok(Directory::from_inode(directory, path, self.filesystem.clone(), 0)?.into())
+            }
+        }
     }
 
     pub fn read(&mut self, entries: &mut [DirEntry]) -> Result<usize, FileSystemError> {
@@ -1104,31 +1222,6 @@ impl Clone for Directory {
 
 #[allow(dead_code)]
 impl FilesystemNode {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, FileSystemError> {
-        let (filesystem, inode) = open_inode(path.as_ref())?;
-
-        Self::from_node(path, inode, filesystem)
-    }
-
-    pub fn from_node<P: AsRef<Path>>(
-        path: P,
-        node: Node,
-        filesystem: Arc<dyn FileSystem>,
-    ) -> Result<Self, FileSystemError> {
-        match node {
-            Node::File(file) => Ok(Self::File(File::from_inode(
-                file,
-                path,
-                filesystem,
-                0,
-                BlockingMode::None,
-            )?)),
-            Node::Directory(directory) => Ok(Self::Directory(Directory::from_inode(
-                directory, path, filesystem, 0,
-            )?)),
-        }
-    }
-
     pub fn as_file(&self) -> Result<&File, FileSystemError> {
         match self {
             Self::File(file) => Ok(file),

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -578,23 +578,13 @@ impl FileSystemMapping {
 pub enum FileSystemError {
     PartitionTableNotFound,
     DeviceNotFound,
-    DiskReadError {
-        sector: u64,
-        error: ide::IdeError,
-    },
+    DiskReadError { sector: u64, error: ide::IdeError },
     FatError(fat::FatError),
     FileNotFound,
     InvalidPath,
     MustBeAbsolute,
     IsNotDirectory,
     IsDirectory,
-    InvalidOffset,
-    /// Unlike InvalidInput, this typically means that the operation parameters were valid,
-    ///  however the error was caused by malformed input data.
-    ///
-    /// For example, a function that reads a file into a string will error with InvalidData
-    /// if the file’s contents are not valid `UTF-8`.
-    InvalidData,
     ReadNotSupported,
     WriteNotSupported,
     OperationNotSupported,

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -62,7 +62,7 @@ impl From<FileSystemError> for SyscallError {
             FileSystemError::EndOfFile => SyscallError::EndOfFile,
             FileSystemError::IsNotDirectory => SyscallError::IsNotDirectory,
             FileSystemError::IsDirectory => SyscallError::IsDirectory,
-            FileSystemError::FileAlreadyExists => todo!(),
+            FileSystemError::AlreadyExists => SyscallError::AlreadyExists,
             FileSystemError::DeviceNotFound => todo!(),
             FileSystemError::BufferNotLargeEnough(_) => SyscallError::BufferTooSmall,
             FileSystemError::DiskReadError { .. }

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -3,7 +3,7 @@ use core::{ffi::CStr, mem};
 use alloc::{borrow::Cow, string::String, vec::Vec};
 use kernel_user_link::{
     clock::ClockType,
-    file::{BlockingMode, DirEntry, FileMeta, SeekFrom, SeekWhence},
+    file::{BlockingMode, DirEntry, FileMeta, OpenOptions, SeekFrom, SeekWhence},
     graphics::{BlitCommand, FrameBufferInfo, GraphicsCommand},
     process::SpawnFileMapping,
     sys_arg,
@@ -221,7 +221,11 @@ fn sys_open(all_state: &mut InterruptAllSavedState) -> SyscallResult {
 
     let absolute_path = path_to_proc_absolute_path(path);
     // TODO: implement flags and access_mode, for now just open file for reading
-    let file = fs::File::open_blocking(absolute_path, blocking_mode)?;
+    let file = fs::File::open_blocking(
+        absolute_path,
+        blocking_mode,
+        OpenOptions::READ | OpenOptions::WRITE,
+    )?;
     let file_index = with_current_process(|process| process.push_fs_node(file));
 
     SyscallResult::Ok(file_index as u64)

--- a/kernel/src/process/syscalls/mod.rs
+++ b/kernel/src/process/syscalls/mod.rs
@@ -63,13 +63,11 @@ impl From<FileSystemError> for SyscallError {
             FileSystemError::IsNotDirectory => SyscallError::IsNotDirectory,
             FileSystemError::IsDirectory => SyscallError::IsDirectory,
             FileSystemError::AlreadyExists => SyscallError::AlreadyExists,
-            FileSystemError::DeviceNotFound => todo!(),
             FileSystemError::BufferNotLargeEnough(_) => SyscallError::BufferTooSmall,
+            FileSystemError::OperationNotSupported => SyscallError::OperationNotSupported,
             FileSystemError::DiskReadError { .. }
-            | FileSystemError::InvalidOffset
             | FileSystemError::FatError(_)
-            | FileSystemError::InvalidData
-            | FileSystemError::OperationNotSupported
+            | FileSystemError::DeviceNotFound
             | FileSystemError::MustBeAbsolute   // should not happen from user mode
             | FileSystemError::PartitionTableNotFound => panic!("should not happen?"),
         }

--- a/libraries/emerald_std/Cargo.toml
+++ b/libraries/emerald_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_std"
-version = "0.2.9"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]

--- a/libraries/emerald_std/src/io.rs
+++ b/libraries/emerald_std/src/io.rs
@@ -6,6 +6,7 @@ pub use kernel_user_link::file::DirFilename;
 pub use kernel_user_link::file::FileMeta;
 pub use kernel_user_link::file::FileStat;
 pub use kernel_user_link::file::FileType;
+pub use kernel_user_link::file::OpenOptions;
 pub use kernel_user_link::file::SeekFrom;
 pub use kernel_user_link::file::SeekWhence;
 pub use kernel_user_link::file::MAX_FILENAME_LEN;
@@ -59,18 +60,18 @@ pub unsafe fn syscall_write(fd: usize, buf: &[u8]) -> Result<u64, SyscallError> 
 
 /// # Safety
 /// This function assumes that `path` is a valid C string.
-/// And that `access_mode` and `flags` are valid.
+/// And that `flags` are valid.
 pub unsafe fn syscall_open(
     path: &CStr,
-    access_mode: usize,
+    open_options: OpenOptions,
     flags: usize,
 ) -> Result<usize, SyscallError> {
     unsafe {
         call_syscall!(
             SYS_OPEN,
-            path.as_ptr() as u64, // path
-            access_mode as u64,   // access_mode
-            flags as u64          // flags
+            path.as_ptr() as u64,  // path
+            open_options.to_u64(), // open_options
+            flags as u64           // flags
         )
         .map(|fd| fd as usize)
     }

--- a/libraries/kernel_user_link/Cargo.toml
+++ b/libraries/kernel_user_link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_kernel_user_link"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]

--- a/libraries/kernel_user_link/Cargo.toml
+++ b/libraries/kernel_user_link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_kernel_user_link"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -250,6 +250,7 @@ pub enum SyscallError {
     InvalidGraphicsBuffer = 19,
     InvalidOffset = 20,
     AlreadyExists = 21,
+    OperationNotSupported = 22,
     InvalidArgument(
         Option<SyscallArgError>,
         Option<SyscallArgError>,
@@ -344,6 +345,7 @@ pub fn syscall_result_to_u64(result: SyscallResult) -> u64 {
                 SyscallError::InvalidGraphicsBuffer => 19 << 56,
                 SyscallError::InvalidOffset => 20 << 56,
                 SyscallError::AlreadyExists => 21 << 56,
+                SyscallError::OperationNotSupported => 22 << 56,
                 SyscallError::InvalidError => panic!("Should never be used"),
             };
 
@@ -403,6 +405,7 @@ pub fn syscall_result_from_u64(value: u64) -> SyscallResult {
             19 => SyscallError::InvalidGraphicsBuffer,
             20 => SyscallError::InvalidOffset,
             21 => SyscallError::AlreadyExists,
+            22 => SyscallError::OperationNotSupported,
             _ => SyscallError::InvalidError,
         };
         SyscallResult::Err(err)

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -249,6 +249,7 @@ pub enum SyscallError {
     GraphicsNotOwned = 18,
     InvalidGraphicsBuffer = 19,
     InvalidOffset = 20,
+    AlreadyExists = 21,
     InvalidArgument(
         Option<SyscallArgError>,
         Option<SyscallArgError>,
@@ -342,6 +343,7 @@ pub fn syscall_result_to_u64(result: SyscallResult) -> u64 {
                 SyscallError::GraphicsNotOwned => 18 << 56,
                 SyscallError::InvalidGraphicsBuffer => 19 << 56,
                 SyscallError::InvalidOffset => 20 << 56,
+                SyscallError::AlreadyExists => 21 << 56,
                 SyscallError::InvalidError => panic!("Should never be used"),
             };
 
@@ -400,6 +402,7 @@ pub fn syscall_result_from_u64(value: u64) -> SyscallResult {
             18 => SyscallError::GraphicsNotOwned,
             19 => SyscallError::InvalidGraphicsBuffer,
             20 => SyscallError::InvalidOffset,
+            21 => SyscallError::AlreadyExists,
             _ => SyscallError::InvalidError,
         };
         SyscallResult::Err(err)

--- a/userspace/graphics/Cargo.toml
+++ b/userspace/graphics/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/video.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-emerald_std = { version = "0.2.6", path = "../../libraries/emerald_std" }
+emerald_std = { version = "0.3.0", path = "../../libraries/emerald_std" }
 emerald_runtime = { version = "0.1.1", path = "../../libraries/emerald_runtime" }
 embedded-graphics = "0.8"
 

--- a/userspace/shell/src/cat.rs
+++ b/userspace/shell/src/cat.rs
@@ -8,7 +8,7 @@ fn main() -> ExitCode {
     let args = std::env::args().collect::<Vec<_>>();
 
     if args.len() < 2 {
-        println!("Usage: {} [file]", args[0]);
+        eprintln!("Usage: {} [file]", args[0]);
         return ExitCode::FAILURE;
     }
 
@@ -17,7 +17,7 @@ fn main() -> ExitCode {
     let mut file = match std::fs::File::open(file) {
         Ok(f) => f,
         Err(e) => {
-            println!("[!] error: {}", e);
+            eprintln!("[!] error: {}", e);
             return ExitCode::FAILURE;
         }
     };
@@ -31,7 +31,7 @@ fn main() -> ExitCode {
                 match s {
                     Ok(s) => print!("{}", s),
                     Err(e) => {
-                        println!(
+                        eprintln!(
                             "\n\n[!] UTF8 Error: {}\nTry to run xxd instead on the file",
                             e
                         );
@@ -40,7 +40,7 @@ fn main() -> ExitCode {
                 }
             }
             Err(e) => {
-                println!("[!] error: {}", e);
+                eprintln!("[!] error: {}", e);
                 return ExitCode::FAILURE;
             }
         }

--- a/userspace/shell/src/echo.rs
+++ b/userspace/shell/src/echo.rs
@@ -8,7 +8,7 @@ fn main() -> ExitCode {
     let args = std::env::args().collect::<Vec<_>>();
 
     if args.len() < 2 {
-        println!("Usage: {} [string]", args[0]);
+        eprintln!("Usage: {} [string]", args[0]);
         return ExitCode::FAILURE;
     }
 

--- a/userspace/shell/src/ls.rs
+++ b/userspace/shell/src/ls.rs
@@ -75,14 +75,14 @@ fn ls(path: &str, print_parent: bool) -> bool {
         Err(e) => {
             match e.kind() {
                 std::io::ErrorKind::NotFound => {
-                    println!("{indent_space}[!] path not found: {}", path);
+                    eprintln!("{indent_space}[!] path not found: {}", path);
                     return false;
                 }
                 std::io::ErrorKind::NotADirectory => {
                     let meta = match std::fs::metadata(path) {
                         Ok(s) => s,
                         Err(e) => {
-                            println!("{indent_space}[!] error: {}", e);
+                            eprintln!("{indent_space}[!] error: {}", e);
                             return false;
                         }
                     };
@@ -93,7 +93,7 @@ fn ls(path: &str, print_parent: bool) -> bool {
                 _ => {}
             }
 
-            println!("{indent_space}[!] error: {}", e);
+            eprintln!("{indent_space}[!] error: {}", e);
             return false;
         }
     };
@@ -107,7 +107,7 @@ fn ls(path: &str, print_parent: bool) -> bool {
     match entries {
         Ok(mut entries) => {
             if entries.is_empty() {
-                println!("{indent_space}[!] empty directory",);
+                eprintln!("{indent_space}[!] empty directory",);
                 return true;
             }
 
@@ -146,7 +146,7 @@ fn ls(path: &str, print_parent: bool) -> bool {
             }
         }
         Err(e) => {
-            println!("{indent_space}[!] error: {}", e);
+            eprintln!("{indent_space}[!] error: {}", e);
         }
     }
 

--- a/userspace/shell/src/shell.rs
+++ b/userspace/shell/src/shell.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    fs,
     io::{self, Write},
     path::Path,
     process::Command,
@@ -56,6 +57,20 @@ fn handle_internal_cmds(cmd: &str, args: &[&str]) -> bool {
                     Ok(seconds) => std::thread::sleep(std::time::Duration::from_secs(seconds)),
                     Err(e) => {
                         println!("sleep: invalid time interval `{}`, e: {e}", args[0])
+                    }
+                }
+            }
+        }
+        "touch" => {
+            if args.is_empty() {
+                println!("touch: missing operand");
+            } else {
+                let path = args[0];
+                let file = fs::OpenOptions::new().create(true).write(true).open(path);
+                match file {
+                    Ok(_) => {}
+                    Err(e) => {
+                        println!("touch: {e}");
                     }
                 }
             }

--- a/userspace/shell/src/time.rs
+++ b/userspace/shell/src/time.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     let args = std::env::args().collect::<Vec<_>>();
 
     if args.len() < 2 {
-        println!("Usage: {} <exe> [args...]", args[0]);
+        eprintln!("Usage: {} <exe> [args...]", args[0]);
         return ExitCode::FAILURE;
     }
 

--- a/userspace/shell/src/tree.rs
+++ b/userspace/shell/src/tree.rs
@@ -117,15 +117,15 @@ fn main() -> ExitCode {
     while let Some(arg) = iter.next() {
         if arg == "-d" {
             let arg = iter.next().unwrap_or_else(|| {
-                println!("missing argument for -d");
+                eprintln!("missing argument for -d");
                 exit(1); // TODO: replace with ExitCode::FAILURE
             });
             depth = Some(arg.parse::<usize>().unwrap_or_else(|_| {
-                println!("invalid argument for -d");
+                eprintln!("invalid argument for -d");
                 exit(1); // TODO: replace with ExitCode::FAILURE
             }));
         } else if arg == "-h" {
-            println!("Usage: {} [-d <n>] [paths...]", args[0]);
+            eprintln!("Usage: {} [-d <n>] [paths...]", args[0]);
             return ExitCode::SUCCESS;
         } else {
             paths.push(arg);

--- a/userspace/shell/src/xxd.rs
+++ b/userspace/shell/src/xxd.rs
@@ -68,6 +68,19 @@ fn main() -> ExitCode {
     let mut buf = [0u8; 1024];
     let mut last_16 = [0u8; 16];
     let mut offset = 0;
+
+    let print_ascii = |last_16: &[u8]| {
+        print!(" "); // more space between the hex and ascii
+        for &c in last_16.iter() {
+            if (0x20..=0x7e).contains(&c) {
+                print!("{}", c as char);
+            } else {
+                print!(".");
+            }
+        }
+        println!();
+    };
+
     'outer: loop {
         match file.read(&mut buf) {
             Ok(0) => break,
@@ -86,15 +99,7 @@ fn main() -> ExitCode {
                     }
 
                     if offset % 16 == 15 {
-                        print!(" "); // more space between the hex and ascii
-                        for &c in last_16.iter() {
-                            if (0x20..=0x7e).contains(&c) {
-                                print!("{}", c as char);
-                            } else {
-                                print!(".");
-                            }
-                        }
-                        println!();
+                        print_ascii(&last_16);
                     }
                     offset += 1;
 
@@ -110,6 +115,18 @@ fn main() -> ExitCode {
                 return ExitCode::FAILURE;
             }
         }
+    }
+
+    if offset % 16 != 0 {
+        // print the remaining ascii characters
+        let remaining = 16 - (offset % 16);
+        for i in 0..remaining {
+            print!("  ");
+            if (offset + i) % 2 == 1 {
+                print!(" "); // space separating each 2 bytes
+            }
+        }
+        print_ascii(&last_16[..(offset % 16)]);
     }
     // print the last line
     println!();

--- a/userspace/shell/src/xxd.rs
+++ b/userspace/shell/src/xxd.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     let args = std::env::args().collect::<Vec<_>>();
 
     if args.len() < 2 {
-        println!("Usage: {} [-l <n>] [-s <n>] [file]", args[0]);
+        eprintln!("Usage: {} [-l <n>] [-s <n>] [file]", args[0]);
         return ExitCode::FAILURE;
     }
 
@@ -24,20 +24,20 @@ fn main() -> ExitCode {
     while let Some(arg) = iter.next() {
         if arg == "-l" {
             let arg = iter.next().unwrap_or_else(|| {
-                println!("missing argument for -l");
+                eprintln!("missing argument for -l");
                 exit(1); // TODO: replace with ExitCode::FAILURE
             });
             limit = Some(arg.parse::<usize>().unwrap_or_else(|_| {
-                println!("invalid argument for -l");
+                eprintln!("invalid argument for -l");
                 exit(1); // TODO: replace with ExitCode::FAILURE
             }));
         } else if arg == "-s" {
             let arg = iter.next().unwrap_or_else(|| {
-                println!("missing argument for -s");
+                eprintln!("missing argument for -s");
                 exit(1); // TODO: replace with ExitCode::FAILURE
             });
             skip = Some(arg.parse::<usize>().unwrap_or_else(|_| {
-                println!("invalid argument for -s");
+                eprintln!("invalid argument for -s");
                 exit(1); // TODO: replace with ExitCode::FAILURE
             }));
         } else {
@@ -46,21 +46,21 @@ fn main() -> ExitCode {
     }
 
     let file = file.unwrap_or_else(|| {
-        println!("missing file argument");
+        eprintln!("missing file argument");
         exit(1); // TODO: replace with ExitCode::FAILURE
     });
 
     let mut file = match std::fs::File::open(file) {
         Ok(f) => f,
         Err(e) => {
-            println!("[!] error: {}", e);
+            eprintln!("[!] error: {}", e);
             return ExitCode::FAILURE;
         }
     };
 
     if let Some(skip) = skip {
         if let Err(e) = file.seek(std::io::SeekFrom::Start(skip as u64)) {
-            println!("[!] error: {}", e);
+            eprintln!("[!] error: {}", e);
             return ExitCode::FAILURE;
         }
     }
@@ -106,7 +106,7 @@ fn main() -> ExitCode {
                 }
             }
             Err(e) => {
-                println!("[!] error: {}", e);
+                eprintln!("[!] error: {}", e);
                 return ExitCode::FAILURE;
             }
         }


### PR DESCRIPTION
## Summary
Added ability to open file with different modes, such as `read`, `write`, `append`, `create`, `truncate`.

Along with that, specifically with `create` flag, we can create files now.

> Note that currently, there is a bug in qemu vvfat, so if you are using that (we do by default), writes will crash qemu.
> I have submitted a patch [here](https://lists.nongnu.org/archive/html/qemu-devel/2024-03/msg06483.html), but at time of writing no response yet.

### Related issue
Fixes #93

## Changes

- Add `OpenOptions` to control access when opening files, and also allow for creating files.
- Added support for that in user mode as well (rust toolchain)


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [ ] Needed README changes
