### PR TITLE
Use framehop tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -53,6 +53,12 @@ checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "autocfg"
@@ -219,6 +225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +247,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "framehop"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1940574e932d1ed75aab25420312c0019d8dd91c6125bd51420272cd072008e"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "fallible-iterator",
+ "gimli 0.29.0",
+ "thiserror-no-std",
 ]
 
 [[package]]
@@ -255,6 +280,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -318,6 +349,7 @@ dependencies = [
  "byteorder",
  "embedded-graphics",
  "emerald_kernel_user_link",
+ "framehop",
  "increasing_heap_allocator",
  "unwinding",
 ]
@@ -547,7 +579,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -586,6 +618,17 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
@@ -612,7 +655,27 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "thiserror-impl-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
+dependencies = [
+ "thiserror-impl-no-std",
 ]
 
 [[package]]
@@ -644,7 +707,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -698,7 +761,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a19a21a537f635c16c7576f22d0f2f7d63353c1337ad4ce0d8001c7952a25b"
 dependencies = [
- "gimli",
+ "gimli 0.28.1",
 ]
 
 [[package]]

--- a/book/src/kernel/memory/memory_layout.md
+++ b/book/src/kernel/memory/memory_layout.md
@@ -19,11 +19,11 @@ FFFF_FFFF_8000_0000..FFFF_FFFF_8010_0000          nothing
 FFFF_FFFF_8010_0000..FFFF_FFFF_8XXX_XXXX          kernel elf (text, rodata, data, bss)
 FFFF_FFFF_8XXX_XXXX..FFFF_FFFF_8800_0000          (kernel end) physical allocator low (until 128MB mark pre-mapped in `boot`)
 FFFF_FFFF_8800_0000..FFFF_FFFF_8900_0000          kernel heap (16MB)
-FFFF_FFFF_8900_0000..FFFF_FFFF_8903_F000          interrupt stacks
+FFFF_FFFF_8900_0000..FFFF_FFFF_890E_7000          interrupt stacks
     FFFF_FFFF_8900_0000..FFFF_FFFF_8900_1000      interrupt stack 0 guard page (4KB) *not mapped by purpose*
-    FFFF_FFFF_8900_1000..FFFF_FFFF_8900_9000      interrupt stack 0 (8 * 4KB = 32KB)
+    FFFF_FFFF_8900_1000..FFFF_FFFF_8902_1000      interrupt stack 0 (32 * 4KB = 128KB)
     ... *repeat for 6 more stacks*
-FFFF_FFFF_8903_F000..FFFF_FFFF_FFFF_F000          Kernel extra (virtual space, free virtual space to use)
+FFFF_FFFF_890E_7000..FFFF_FFFF_FFFF_F000          Kernel extra (virtual space, free virtual space to use)
 ```
 
 The kernel is loaded by the bootloader at physical address `0x10_0000`, and then it will
@@ -43,7 +43,7 @@ Its very simple, it will take memory from the `kernel extra` space, and map it t
 ### Process specific kernel layout
 ```txt
 FFFF_FF80_0000_0000..FFFF_FF80_0000_1000          process kernel stack guard page (4KB) *not mapped by purpose*
-FFFF_FF80_0000_1000..FFFF_FF80_0000_9000          process kernel stack (8 * 4KB = 32KB)
+FFFF_FF80_0000_1000..FFFF_FF80_0004_1000          process kernel stack (64 * 4KB = 256KB)
 ```
 
 This is a space specific to each process, but reside in kernel space.

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -12,3 +12,4 @@ embedded-graphics = { version = "0.8.1", default-features = false }
 byteorder = { version = "1.5", default-features = false }
 blinkcast = "0.2"
 unwinding = { version = "0.2", features = ['unwinder', 'personality', 'fde-static'], default-features = false }
+framehop =  { version = "0.11.2", default-features = false }

--- a/kernel/src/cpu/idt.rs
+++ b/kernel/src/cpu/idt.rs
@@ -309,7 +309,10 @@ pub extern "cdecl" fn rust_interrupt_handler_for_all_state(mut state: InterruptA
 }
 
 extern "x86-interrupt" fn default_handler<const N: u8>(frame: InterruptStackFrame64) {
-    panic!("[{N}] Got exception: \n frame: {:x?}", frame);
+    println!("[{N}] Got exception: \n frame: {:x?}", frame);
+
+    crate::panic_handler::print_originating_stack_trace(&frame, super::rbp!());
+    panic!("Unhandled exception");
 }
 
 extern "x86-interrupt" fn default_handler_with_error<const N: u8>(
@@ -322,7 +325,10 @@ extern "x86-interrupt" fn default_handler_with_error<const N: u8>(
     }
     let current_cpu = super::cpu();
     let proc_id = current_cpu.context.map(|_| current_cpu.process_id);
-    panic!(
+    println!(
         "[{N}] {proc_id:?} Got exception: \n frame: {frame:x?}\n error: {error_code:016X}\n cr2: {cr2:X}",
     );
+
+    crate::panic_handler::print_originating_stack_trace(&frame, super::rbp!());
+    panic!("Unhandled exception");
 }

--- a/kernel/src/cpu/mod.rs
+++ b/kernel/src/cpu/mod.rs
@@ -309,3 +309,48 @@ pub unsafe fn read_tsc() -> u64 {
     core::arch::asm!("rdtsc", out("eax") low, out("edx") high, options(nomem, nostack, preserves_flags));
     ((high as u64) << 32) | (low as u64)
 }
+
+#[macro_export]
+macro_rules! rip {
+    () => {
+        {
+            let rip: u64;
+            unsafe {
+                core::arch::asm!("lea {0:r}, [rip]", out(reg) rip, options(nomem, nostack, preserves_flags));
+            }
+            rip
+        }
+    };
+}
+#[allow(unused_imports)]
+pub use rip;
+
+#[macro_export]
+macro_rules! rbp {
+    () => {
+        {
+            let rbp: u64;
+            unsafe {
+                core::arch::asm!("mov {0:r}, rbp", out(reg) rbp, options(nomem, nostack, preserves_flags));
+            }
+            rbp
+        }
+    };
+}
+#[allow(unused_imports)]
+pub use rbp;
+
+#[macro_export]
+macro_rules! rsp {
+    () => {
+        {
+            let rsp: u64;
+            unsafe {
+                core::arch::asm!("mov {0:r}, rsp", out(reg) rsp, options(nomem, nostack, preserves_flags));
+            }
+            rsp
+        }
+    };
+}
+#[allow(unused_imports)]
+pub use rsp;

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -29,7 +29,7 @@ pub const KERNEL_HEAP_BASE: usize = KERNEL_END;
 pub const KERNEL_HEAP_SIZE: usize = 0x100_0000; // 16MB
 
 // The size of the stack for interrupt handlers
-pub const INTR_STACK_SIZE: usize = PAGE_4K * 8;
+pub const INTR_STACK_SIZE: usize = PAGE_4K * 32;
 pub const INTR_STACK_EMPTY_SIZE: usize = PAGE_4K;
 pub const INTR_STACK_ENTRY_SIZE: usize = INTR_STACK_SIZE + INTR_STACK_EMPTY_SIZE;
 pub const INTR_STACK_BASE: usize = KERNEL_HEAP_BASE + KERNEL_HEAP_SIZE;
@@ -54,7 +54,7 @@ pub const PROCESS_KERNEL_STACK_GUARD: usize = PAGE_4K;
 // space so that other processes don't override it when being run
 pub const PROCESS_KERNEL_STACK_BASE: usize =
     KERNEL_PROCESS_VIRTUAL_ADDRESS_START + PROCESS_KERNEL_STACK_GUARD;
-pub const PROCESS_KERNEL_STACK_SIZE: usize = PAGE_4K * 8;
+pub const PROCESS_KERNEL_STACK_SIZE: usize = PAGE_4K * 64;
 pub const PROCESS_KERNEL_STACK_END: usize = PROCESS_KERNEL_STACK_BASE + PROCESS_KERNEL_STACK_SIZE;
 
 #[allow(dead_code)]

--- a/kernel/src/memory_management/memory_layout.rs
+++ b/kernel/src/memory_management/memory_layout.rs
@@ -9,6 +9,7 @@ extern "C" {
     static rodata_end: usize;
     static data_end: usize;
     static stack_guard_page: usize;
+    static __eh_frame: usize;
 }
 
 // The virtual address of the kernel
@@ -87,6 +88,14 @@ pub fn kernel_elf_data_end() -> usize {
 
 pub fn stack_guard_page_ptr() -> usize {
     (unsafe { &stack_guard_page } as *const usize as usize)
+}
+
+pub fn eh_frame_start() -> usize {
+    (unsafe { &__eh_frame } as *const usize as usize)
+}
+
+pub fn eh_frame_end() -> usize {
+    (unsafe { &rodata_end } as *const usize as usize)
 }
 
 pub trait AlignMem: Sized {

--- a/kernel/src/panic_handler.rs
+++ b/kernel/src/panic_handler.rs
@@ -1,49 +1,160 @@
 use core::{
-    ffi::c_void,
     hint,
     panic::PanicInfo,
     sync::atomic::{AtomicI32, Ordering},
 };
 
-use unwinding::abi::{UnwindContext, UnwindReasonCode, _Unwind_Backtrace, _Unwind_GetIP};
+use alloc::{string::String, vec::Vec};
+use framehop::{
+    x86_64::{CacheX86_64, UnwindRegsX86_64, UnwinderX86_64},
+    ExplicitModuleSectionInfo, Module, Unwinder,
+};
 
-use crate::cpu;
+use kernel_user_link::process::process_metadata;
+// for some reason, removing this doesn't make the compiler find `eh_personality` in the `unwinding` crate
+// so keeping it here :D
+#[allow(unused_imports)]
+use unwinding::abi::UnwindContext;
+
+use crate::{
+    cpu::{self, idt::InterruptStackFrame64},
+    memory_management::memory_layout::{
+        eh_frame_end, eh_frame_start, kernel_elf_end, kernel_text_end, KERNEL_LINK,
+    },
+    process::scheduler::with_current_process,
+};
 
 // this should be 'core-local/thread-local', but that's okay, as we want to halt the whole kernel
 static PANIC_COUNT: AtomicI32 = AtomicI32::new(0);
 
-fn stack_trace() {
-    struct CallbackData {
-        counter: usize,
-    }
-    extern "C" fn callback(unwind_ctx: &UnwindContext<'_>, arg: *mut c_void) -> UnwindReasonCode {
-        let data = unsafe { &mut *(arg as *mut CallbackData) };
-        data.counter += 1;
-        println!("{:4}:{:#19x}", data.counter, _Unwind_GetIP(unwind_ctx));
-        UnwindReasonCode::NO_REASON
-    }
-    let mut data = CallbackData { counter: 0 };
-    _Unwind_Backtrace(callback, &mut data as *mut _ as _);
+pub fn print_kernel_stack_trace(rip: u64, rsp: u64, rbp: u64) {
+    cpu::cpu().push_cli();
 
-    print!("You can use this command to get information about the trace (since we don't have debug symbols here):\n$ addr2line -f -C -e ./target/x86-64-os/debug/kernel");
-    extern "C" fn callback2(unwind_ctx: &UnwindContext<'_>, _arg: *mut c_void) -> UnwindReasonCode {
-        print!(" {:#x}", _Unwind_GetIP(unwind_ctx));
-        UnwindReasonCode::NO_REASON
+    let mut cache = CacheX86_64::<_>::new();
+    let mut unwinder = UnwinderX86_64::new();
+
+    let module = Module::new(
+        String::from("kernel"),
+        KERNEL_LINK as u64..(kernel_elf_end()) as u64,
+        KERNEL_LINK as u64,
+        ExplicitModuleSectionInfo {
+            base_svma: KERNEL_LINK as _,
+            text_svma: Some(KERNEL_LINK as _..kernel_text_end() as _),
+            text: Some(unsafe {
+                core::slice::from_raw_parts(KERNEL_LINK as _, kernel_text_end() - KERNEL_LINK)
+            }),
+            eh_frame_svma: Some(eh_frame_start() as _..eh_frame_end() as _),
+            eh_frame: Some(unsafe {
+                core::slice::from_raw_parts(
+                    eh_frame_start() as _,
+                    eh_frame_end() - eh_frame_start(),
+                )
+            }),
+            ..Default::default()
+        },
+    );
+    unwinder.add_module(module);
+
+    let mut read_stack = |addr| Ok(unsafe { (addr as *const u64).read_volatile() });
+
+    let mut iter = unwinder.iter_frames(
+        rip,
+        UnwindRegsX86_64::new(rip, rsp, rbp),
+        &mut cache,
+        &mut read_stack,
+    );
+
+    println!("Stack trace:");
+    let mut i = 0;
+    let mut frames = Vec::new();
+    while let Ok(Some(frame)) = iter.next() {
+        println!("{i:4}:{:#19x}", frame.address());
+        frames.push(frame.address());
+        i += 1;
     }
-    _Unwind_Backtrace(callback2, core::ptr::null_mut() as _);
-    println!("\nhalting...");
+
+    print!("You can use this command to get information about the trace (since we don't have debug symbols here):\n$ addr2line -f -C -e ");
+    #[cfg(debug_assertions)]
+    print!("./target/x86-64-os/debug/kernel");
+    #[cfg(not(debug_assertions))]
+    print!("./target/x86-64-os/release/kernel");
+    for frame in frames.iter() {
+        print!(" {:#x}", frame);
+    }
+    println!();
+
+    cpu::cpu().pop_cli();
 }
 
-fn panic_trace() -> ! {
-    if PANIC_COUNT.load(Ordering::Relaxed) >= 1 {
-        stack_trace();
-        println!("thread panicked while processing panic. halting...");
-        abort();
+pub fn print_process_stack_trace(frame: &InterruptStackFrame64, rbp: u64) {
+    cpu::cpu().push_cli();
+
+    assert!(frame.cs & 0x3 == 3, "We are in user mode");
+
+    let meta = process_metadata();
+
+    let module = Module::new(
+        String::from("exe"),
+        meta.image_base as _..(meta.image_base + meta.image_size) as _,
+        meta.image_base as _,
+        ExplicitModuleSectionInfo {
+            base_svma: meta.image_base as _,
+            text_svma: Some(meta.text_address as _..(meta.text_address + meta.text_size) as _),
+            text: Some(unsafe {
+                core::slice::from_raw_parts(meta.text_address as _, meta.text_size)
+            }),
+            eh_frame_svma: Some(
+                meta.eh_frame_address as _..(meta.eh_frame_address + meta.eh_frame_size) as _,
+            ),
+            eh_frame: Some(unsafe {
+                core::slice::from_raw_parts(meta.eh_frame_address as _, meta.eh_frame_size)
+            }),
+            ..Default::default()
+        },
+    );
+    let mut cache = CacheX86_64::new();
+    let mut unwinder: UnwinderX86_64<&[u8]> = UnwinderX86_64::new();
+    unwinder.add_module(module);
+
+    let mut read_stack = |addr| Ok(unsafe { (addr as *const u64).read_volatile() });
+
+    let mut iter = unwinder.iter_frames(
+        frame.rip as _,
+        UnwindRegsX86_64::new(frame.rip as _, frame.rsp as _, rbp as _),
+        &mut cache,
+        &mut read_stack,
+    );
+
+    println!("Stack trace:");
+    let mut i = 0;
+    let mut frames = Vec::new();
+    while let Ok(Some(frame)) = iter.next() {
+        println!("{i:4}:{:#19x}", frame.address());
+        frames.push(frame.address());
+        i += 1;
     }
-    PANIC_COUNT.store(1, Ordering::Relaxed);
-    stack_trace();
-    println!("failed to initiate panic, maybe, we don't have `eh_frame` data?. halting...");
-    abort()
+
+    with_current_process(|process| {
+        print!("You can use this command to get information about the trace (since we don't have debug symbols here):\n$ addr2line -f -C -e ./filesystem{}", process.file_path().as_str());
+    });
+    for frame in frames.iter() {
+        print!(" {:#x}", frame);
+    }
+    println!();
+
+    cpu::cpu().pop_cli();
+}
+
+pub fn print_originating_stack_trace(frame: &InterruptStackFrame64, rbp: u64) {
+    if frame.cs & 0x3 == 3 {
+        print_process_stack_trace(frame, rbp);
+    } else {
+        print_kernel_stack_trace(frame.rip, frame.rsp, rbp);
+    }
+}
+
+fn stack_trace() {
+    print_kernel_stack_trace(cpu::rip!(), cpu::rsp!(), cpu::rbp!());
 }
 
 #[panic_handler]
@@ -51,7 +162,16 @@ fn panic(info: &PanicInfo<'_>) -> ! {
     unsafe { cpu::clear_interrupts() };
     println!("{}", info);
 
-    panic_trace()
+    if PANIC_COUNT.load(Ordering::Relaxed) >= 1 {
+        // we can't print the trace, as the panic probably happened while printing the trace
+        println!("thread panicked while processing panic. halting without backtrace...");
+        abort();
+    }
+
+    PANIC_COUNT.store(1, Ordering::Relaxed);
+    stack_trace();
+    println!("failed to initiate panic, maybe, we don't have `eh_frame` data?. halting...");
+    abort()
 }
 
 fn abort() -> ! {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -9,7 +9,10 @@ use kernel_user_link::process::{PriorityLevel, ProcessMetadata};
 use crate::{
     cpu::{self, gdt},
     executable::{elf, load_elf_to_vm},
-    fs,
+    fs::{
+        self,
+        path::{Path, PathBuf},
+    },
     graphics::vga,
     memory_management::{
         memory_layout::{align_down, align_up, is_aligned, GB, KERNEL_BASE, MB, PAGE_2M, PAGE_4K},
@@ -108,6 +111,7 @@ pub struct Process {
     file_index_allocator: GoingUpAllocator,
 
     argv: Vec<String>,
+    file_path: PathBuf,
 
     current_dir: fs::Directory,
 
@@ -202,6 +206,7 @@ impl Process {
             open_filesystem_nodes: BTreeMap::new(),
             file_index_allocator: GoingUpAllocator::new(),
             argv,
+            file_path: file.path().to_path_buf(),
             current_dir,
             stack_ptr_end: stack_end - 8, // 8 bytes for padding
             stack_size,
@@ -363,6 +368,10 @@ impl Process {
 
     pub fn set_priority(&mut self, priority: PriorityLevel) {
         self.priority = priority;
+    }
+
+    pub fn file_path(&self) -> &Path {
+        self.file_path.as_path()
     }
 }
 


### PR DESCRIPTION
## Summary

We are adding [framehop](https://docs.rs/framehop/latest/framehop/) library to perform traces.

Its different from `unwinding` in that it allow us to unwind from locations beside "current location", i.e. I can collect trace for userspace execution from the kernel for example.

There is an issue with it though, it uses more stack than `unwinding` and it could be less stable, i.e. if we corrupted the memory somehow and got into an exception, `unwinding` would work probably, but this would probably not print good traces, but the memory is corrupted at that point so not sure

### Related issue

No specific issue, but related to #81 

## Changes

<!-- Please provide some more detail regarding the changes.
Add any additional information, configuration, or data that might be necessary for the review
Mention the type of each change. i.e. `Addition`, `Bug Fix`, `Documentation`, etc... -->

- Add `framehop` depenancy
- `framehop` is used to print a trace into the child process if it caused an exception, as well as kernel traces for exceptions. The normal panic in the kernel still use the old method with `unwinding` as it is more memory efficient

## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
