### PR TITLE
Scheduler improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "emerald_kernel_user_link"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "emerald_std"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compiler_builtins",
  "emerald_kernel_user_link",

--- a/book/src/kernel/processes/index.md
+++ b/book/src/kernel/processes/index.md
@@ -23,7 +23,7 @@ The process structure [`Process`][process_structure] contain all the information
 - `heap_start`: The start address of the heap, this will be padded by around `1MB` from the end of the `ELF` file loadded into memory.
 - `heap_size`: The current size of the heap. The user process can request more heap space with the [`inc_dec_heap`](./syscalls.md#syscalls-list) system call.
 - `heap_max`: The maximum possible size of the heap, this is not changed, currently set to `1GB`.
-- `status`: The status of the process, see [scheduler](./scheduler.md) for more information.
+- `priority`: The priority of the process, this is used by the scheduler. see [`PriorityLevel`](https://docs.rs/emerald_kernel_user_link/latest/emerald_kernel_user_link/process/enum.PriorityLevel.html).)
 - `exit_code`: The exit code of the process, if the process is exited, this will be set to the exit code.
 - `children_exits`: A list of the children processes that have exited, with their exit code (see #process-exit later for more information).
 
@@ -77,10 +77,11 @@ This structure is placed in a static location in userspace memory (see [user mem
 - image size.
 - program header offset (even though it can probably be obtained by reading the image header).
 - `eh_frame` address and size, this is used to implement unwinding.
+- `text` address and size, this is useful for debugging and getting backtrace from usermode.
 
 ## Process Exit
 
-When the syscall `exit` is called, the process is marked as `Exited`, and the exit code is set.
+When the syscall `exit` is called, the process moved to `exited` list, and the exit code is set.
 
 The `Exited` process will be removed from the `scheduler`'s list, at the next `schedule` call, see [scheduler](./scheduler.md) for more information.
 

--- a/book/src/kernel/processes/syscalls.md
+++ b/book/src/kernel/processes/syscalls.md
@@ -49,3 +49,4 @@ these pointers/values to the correct types.
 | `get_time` | `clock_type: ClockType, time: *mut ClockTime` | `()` | Gets the time based on the `clock_type`, see [Clocks](../clocks/index.md) |
 | `graphics` | `command: GraphicsCommand, extra: *mut ()` | `()` | Graphics operations, see [Graphics:VGA](../graphics/vga.md#graphics-command) |
 | `seek` | `file_index: usize, whence: SeekWhence, offset: i64` | `new_offset: u64` | Seeks a file |
+| `priority` | `pid: u64, priority: Option<PriorityLevel>` | `PriorityLevel` | Sets and gets the priority of a process |

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kernel_user_link = { version="0.2.0", path = "../libraries/kernel_user_link", package = "emerald_kernel_user_link" }
+kernel_user_link = { version="0.2.12", path = "../libraries/kernel_user_link", package = "emerald_kernel_user_link" }
 increasing_heap_allocator = { version="0.1.3", path = "../libraries/increasing_heap_allocator" }
 embedded-graphics = { version = "0.8.1", default-features = false }
 byteorder = { version = "1.5", default-features = false }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -2,6 +2,7 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 #![feature(linked_list_cursors)]
+#![feature(const_binary_heap_constructor)]
 
 extern crate alloc;
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -3,6 +3,7 @@
 #![feature(abi_x86_interrupt)]
 #![feature(linked_list_cursors)]
 #![feature(const_binary_heap_constructor)]
+#![feature(btree_extract_if)]
 
 extern crate alloc;
 

--- a/kernel/src/memory_management/virtual_memory_mapper.rs
+++ b/kernel/src/memory_management/virtual_memory_mapper.rs
@@ -303,6 +303,12 @@ impl VirtualMemoryMapper {
         }
     }
 
+    /// Return `true` if the current VM is used by the current cpu
+    pub fn is_used_by_me(&self) -> bool {
+        let cr3 = unsafe { cpu::get_cr3() };
+        cr3 == self.page_map_l4.as_physical()
+    }
+
     /// # Safety
     /// This must be used with caution, it must never be switched while we are using
     /// memory from the same regions, i.e. kernel stack while we are in an interrupt

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -19,6 +19,8 @@ use crate::{
     },
 };
 
+use self::scheduler::PriorityLevel;
+
 static PROCESS_ID_ALLOCATOR: GoingUpAllocator = GoingUpAllocator::new();
 // TODO: add dynamic stack allocation
 const INITIAL_STACK_SIZE_PAGES: usize = 256; // 1MB
@@ -118,6 +120,8 @@ pub struct Process {
     heap_size: usize,
     heap_max: usize,
 
+    priority: PriorityLevel,
+
     // split from the state, so that we can keep it as a simple enum
     exit_code: i32,
     children_exits: BTreeMap<u64, i32>,
@@ -206,6 +210,7 @@ impl Process {
             heap_start,
             heap_size,
             heap_max,
+            priority: PriorityLevel::Normal,
             exit_code: 0,
             children_exits: BTreeMap::new(),
         })
@@ -352,6 +357,10 @@ impl Process {
 
     pub fn set_current_dir(&mut self, current_dir: fs::Directory) {
         self.current_dir = current_dir;
+    }
+
+    pub fn change_priority(&mut self, priority: PriorityLevel) {
+        self.priority = priority;
     }
 }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -4,7 +4,7 @@ mod syscalls;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
-use kernel_user_link::process::ProcessMetadata;
+use kernel_user_link::process::{PriorityLevel, ProcessMetadata};
 
 use crate::{
     cpu::{self, gdt},
@@ -18,8 +18,6 @@ use crate::{
         },
     },
 };
-
-use self::scheduler::PriorityLevel;
 
 static PROCESS_ID_ALLOCATOR: GoingUpAllocator = GoingUpAllocator::new();
 // TODO: add dynamic stack allocation
@@ -359,7 +357,11 @@ impl Process {
         self.current_dir = current_dir;
     }
 
-    pub fn change_priority(&mut self, priority: PriorityLevel) {
+    pub fn get_priority(&self) -> PriorityLevel {
+        self.priority
+    }
+
+    pub fn set_priority(&mut self, priority: PriorityLevel) {
         self.priority = priority;
     }
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -467,6 +467,7 @@ impl Process {
 
 impl Drop for Process {
     fn drop(&mut self) {
+        assert!(!self.vm.is_used_by_me());
         self.vm.unmap_process_memory();
     }
 }

--- a/kernel/src/process/scheduler.rs
+++ b/kernel/src/process/scheduler.rs
@@ -30,24 +30,6 @@ pub enum ProcessState {
     WaitingForTime(ClockTime),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-#[allow(dead_code)]
-pub enum PriorityLevel {
-    VeryLow = 1,
-    Low = 2,
-    Normal = 3,
-    High = 4,
-    VeryHigh = 5,
-}
-
-impl PriorityLevel {
-    pub fn counter_decrement(&self) -> u64 {
-        // the higher the value, the lower the priority
-        6 - *self as u64
-    }
-}
-
 /// A wrapper around [`Process`] that has extra details the scheduler cares about
 struct SchedulerProcess {
     // using box here so that moving this around won't be as expensive
@@ -236,7 +218,9 @@ pub fn schedule() -> ! {
                 let mut inner_proc = top.process.borrow_mut();
                 pid = inner_proc.id;
 
-                top.priority_counter -= inner_proc.priority.counter_decrement();
+                // the higher the value, the lower the priority
+                let decrement = 6 - inner_proc.priority as u64;
+                top.priority_counter -= decrement;
 
                 scheduler.max_priority = top.priority_counter;
                 // SAFETY: we are the scheduler and running in kernel space, so its safe to switch to this vm

--- a/kernel/src/process/scheduler.rs
+++ b/kernel/src/process/scheduler.rs
@@ -30,6 +30,24 @@ pub enum ProcessState {
     WaitingForTime(ClockTime),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum PriorityLevel {
+    VeryLow = 1,
+    Low = 2,
+    Normal = 3,
+    High = 4,
+    VeryHigh = 5,
+}
+
+impl PriorityLevel {
+    pub fn counter_decrement(&self) -> u64 {
+        // the higher the value, the lower the priority
+        6 - *self as u64
+    }
+}
+
 /// A wrapper around [`Process`] that has extra details the scheduler cares about
 struct SchedulerProcess {
     // using box here so that moving this around won't be as expensive
@@ -219,8 +237,7 @@ pub fn schedule() -> ! {
             assert!(top.state == ProcessState::Scheduled);
             // found a process to run
             top.state = ProcessState::Running;
-            // TODO: add priority levels support
-            top.priority_counter -= 1;
+            top.priority_counter -= top.process.priority.counter_decrement();
             scheduler.max_priority = top.priority_counter;
             // SAFETY: we are the scheduler and running in kernel space, so its safe to switch to this vm
             // as it has clones of our kernel mappings

--- a/libraries/emerald_std/Cargo.toml
+++ b/libraries/emerald_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_std"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]
@@ -14,7 +14,7 @@ categories = ["os"]
 
 [dependencies]
 increasing_heap_allocator = { version="0.1.3", path = "../increasing_heap_allocator" }
-kernel_user_link = { version="0.2.9", path = "../kernel_user_link", package = "emerald_kernel_user_link" }
+kernel_user_link = { version="0.2.12", path = "../kernel_user_link", package = "emerald_kernel_user_link" }
 # for now, waiting for the PR https://github.com/rust-lang/libm/pull/290 to be merged
 libm = { version = "0.2.8", git = "https://github.com/Amjad50/libm", branch = "compiling_libm_for_std" }
 

--- a/libraries/kernel_user_link/Cargo.toml
+++ b/libraries/kernel_user_link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald_kernel_user_link"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 readme = "README.md"
 authors = ["Amjad Alsharafi"]

--- a/libraries/kernel_user_link/src/process.rs
+++ b/libraries/kernel_user_link/src/process.rs
@@ -5,6 +5,33 @@ pub struct SpawnFileMapping {
     pub dst_fd: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PriorityLevel {
+    VeryLow = 1,
+    Low = 2,
+    Normal = 3,
+    High = 4,
+    VeryHigh = 5,
+}
+
+impl PriorityLevel {
+    pub fn from_u64(value: u64) -> Option<Self> {
+        match value {
+            1 => Some(Self::VeryLow),
+            2 => Some(Self::Low),
+            3 => Some(Self::Normal),
+            4 => Some(Self::High),
+            5 => Some(Self::VeryHigh),
+            _ => None,
+        }
+    }
+
+    pub fn to_u64(self) -> u64 {
+        self as u64
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ProcessMetadata {
     pub pid: u64,

--- a/libraries/kernel_user_link/src/syscalls.rs
+++ b/libraries/kernel_user_link/src/syscalls.rs
@@ -6,7 +6,7 @@ mod types_conversions;
 /// user-kernel
 pub const SYSCALL_INTERRUPT_NUMBER: u8 = 0xFE;
 
-pub const NUM_SYSCALLS: usize = 21;
+pub const NUM_SYSCALLS: usize = 22;
 
 mod numbers {
     pub const SYS_OPEN: u64 = 0;
@@ -31,6 +31,7 @@ mod numbers {
     pub const SYS_GET_TIME: u64 = 18;
     pub const SYS_GRAPHICS: u64 = 19;
     pub const SYS_SEEK: u64 = 20;
+    pub const SYS_PRIORITY: u64 = 21;
 }
 pub use numbers::*;
 


### PR DESCRIPTION
## Summary
Improve the scheduler for performance and ease of use

### Related issue

<!-- Mention any relevant issues like #123 -->
No open issues on this

## Changes

<!-- Please provide some more detail regarding the changes.
Add any additional information, configuration, or data that might be necessary for the review
Mention the type of each change. i.e. `Addition`, `Bug Fix`, `Documentation`, etc... -->

- Used `BinaryHeap` for scheduled processes, big performance improvement when contended, as we don't need to loop over all elements
- Use `BTreeMap` for running processes, this is splitted from scheduled processes list
- Add `priority` syscall to control any process priority


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Documentation
- [x] Needed README changes
