### PR TITLE
ACPI/AML representation restructure

### DIFF
--- a/book/src/kernel/boot/cmdline.md
+++ b/book/src/kernel/boot/cmdline.md
@@ -48,7 +48,7 @@ Here is the supported properties:
 | `max_log_level` | `LogLevel` (`trace/debug/info/warn/error`) | Maximum log level                                        | `LogLevel::Info` |
 | `log_file`      | `&str`                                     | Log file path                                            | `"/kernel.log"`  |
 | `allow_hpet`    | `bool`                                     | Allow `HPET` (if present), otherwise always use `PIT`    | `true`           |
-| `log_aml`       | `bool`                                     | Log the AML content as ASL code on boot from ACPI tables | `true`           |
+| `log_aml`       | `LogAml` (`off/normal/structured`)         | Log the AML content as ASL code on boot from ACPI tables | `LogAml::Off`    |
 
 
 If we write these in a command line, it will look like:

--- a/book/src/kernel/boot/cmdline.md
+++ b/book/src/kernel/boot/cmdline.md
@@ -41,13 +41,14 @@ last value will be used.
 Here is the supported properties:
 
 
-| Property        | Type                                       | Description                                           | Default          |
-|-----------------|--------------------------------------------|-------------------------------------------------------|------------------|
-| `uart`          | `bool`                                     | Enable UART/serial interface                          | `true`           |
-| `uart_baud`     | `u32`                                      | UART baud rate                                        | `115200`         |
-| `max_log_level` | `LogLevel` (`trace/debug/info/warn/error`) | Maximum log level                                     | `LogLevel::Info` |
-| `log_file`      | `&str`                                     | Log file path                                         | `"/kernel.log"`  |
-| `allow_hpet`    | `bool`                                     | Allow `HPET` (if present), otherwise always use `PIT` | `true`           |
+| Property        | Type                                       | Description                                              | Default          |
+|-----------------|--------------------------------------------|----------------------------------------------------------|------------------|
+| `uart`          | `bool`                                     | Enable UART/serial interface                             | `true`           |
+| `uart_baud`     | `u32`                                      | UART baud rate                                           | `115200`         |
+| `max_log_level` | `LogLevel` (`trace/debug/info/warn/error`) | Maximum log level                                        | `LogLevel::Info` |
+| `log_file`      | `&str`                                     | Log file path                                            | `"/kernel.log"`  |
+| `allow_hpet`    | `bool`                                     | Allow `HPET` (if present), otherwise always use `PIT`    | `true`           |
+| `log_aml`       | `bool`                                     | Log the AML content as ASL code on boot from ACPI tables | `true`           |
 
 
 If we write these in a command line, it will look like:

--- a/kernel/src/acpi/aml/mod.rs
+++ b/kernel/src/acpi/aml/mod.rs
@@ -1,0 +1,32 @@
+mod parser;
+mod structured;
+
+pub use parser::{AmlCode, AmlParseError};
+use structured::StructuredAml;
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Aml {
+    code: AmlCode,
+    structured: StructuredAml,
+}
+
+impl Aml {
+    pub fn parse(body: &[u8]) -> Result<Self, AmlParseError> {
+        let code = parser::parse_aml(body)?;
+        Ok(Self {
+            structured: StructuredAml::parse(&code),
+            code,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn code(&self) -> &AmlCode {
+        &self.code
+    }
+
+    #[allow(dead_code)]
+    pub fn structured(&self) -> &StructuredAml {
+        &self.structured
+    }
+}

--- a/kernel/src/acpi/aml/parser.rs
+++ b/kernel/src/acpi/aml/parser.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
@@ -7,6 +5,7 @@ use alloc::{
     string::String,
     vec::Vec,
 };
+use core::fmt;
 use tracing::trace;
 
 #[derive(Debug, Clone)]
@@ -31,7 +30,7 @@ pub fn parse_aml(code: &[u8]) -> Result<AmlCode, AmlParseError> {
 
 #[derive(Debug, Clone)]
 pub struct AmlCode {
-    term_list: Vec<AmlTerm>,
+    pub(super) term_list: Vec<AmlTerm>,
 }
 
 #[derive(Debug, Clone)]
@@ -149,8 +148,8 @@ pub enum Target {
 
 #[derive(Debug, Clone)]
 pub struct ScopeObj {
-    name: String,
-    term_list: Vec<AmlTerm>,
+    pub(super) name: String,
+    pub(super) term_list: Vec<AmlTerm>,
 }
 
 impl ScopeObj {
@@ -167,10 +166,10 @@ impl ScopeObj {
 
 #[derive(Debug, Clone)]
 pub struct RegionObj {
-    name: String,
-    region_space: u8,
-    region_offset: TermArg,
-    region_length: TermArg,
+    pub(super) name: String,
+    pub(super) region_space: u8,
+    pub(super) region_offset: TermArg,
+    pub(super) region_length: TermArg,
 }
 
 impl RegionObj {
@@ -193,9 +192,9 @@ impl RegionObj {
 
 #[derive(Debug, Clone)]
 pub struct FieldDef {
-    name: String,
-    flags: u8,
-    fields: Vec<FieldElement>,
+    pub(super) name: String,
+    pub(super) flags: u8,
+    pub(super) fields: Vec<FieldElement>,
 }
 
 impl FieldDef {
@@ -214,10 +213,10 @@ impl FieldDef {
 
 #[derive(Debug, Clone)]
 pub struct IndexFieldDef {
-    name: String,
-    index_name: String,
-    flags: u8,
-    fields: Vec<FieldElement>,
+    pub(super) name: String,
+    pub(super) index_name: String,
+    pub(super) flags: u8,
+    pub(super) fields: Vec<FieldElement>,
 }
 
 impl IndexFieldDef {
@@ -246,9 +245,9 @@ pub enum FieldElement {
 
 #[derive(Debug, Clone)]
 pub struct MethodObj {
-    name: String,
-    flags: u8,
-    term_list: Vec<AmlTerm>,
+    pub name: String,
+    pub flags: u8,
+    pub term_list: Vec<AmlTerm>,
 }
 
 impl MethodObj {
@@ -297,11 +296,11 @@ impl PredicateBlock {
 
 #[derive(Debug, Clone)]
 pub struct ProcessorDeprecated {
-    name: String,
-    unk1: u8,
-    unk2: u32,
-    unk3: u8,
-    term_list: Vec<AmlTerm>,
+    pub(super) name: String,
+    pub(super) unk1: u8,
+    pub(super) unk2: u32,
+    pub(super) unk3: u8,
+    pub(super) term_list: Vec<AmlTerm>,
 }
 
 impl ProcessorDeprecated {
@@ -334,10 +333,10 @@ impl ProcessorDeprecated {
 
 #[derive(Debug, Clone)]
 pub struct PowerResource {
-    name: String,
-    system_level: u8,
-    resource_order: u16,
-    term_list: Vec<AmlTerm>,
+    pub(super) name: String,
+    pub(super) system_level: u8,
+    pub(super) resource_order: u16,
+    pub(super) term_list: Vec<AmlTerm>,
 }
 
 impl PowerResource {
@@ -1243,14 +1242,18 @@ impl Parser<'_> {
 // display impls, we are not using `fmt::Display`, since we have a special `depth` to propagate
 // we could have used a `fmt::Display` wrapper, which is another approach, not sure which is better.
 
-fn display_depth(f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+pub(super) fn display_depth(f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
     for _ in 0..depth {
         write!(f, "  ")?;
     }
     Ok(())
 }
 
-fn display_terms(term_list: &[AmlTerm], f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+pub(super) fn display_terms(
+    term_list: &[AmlTerm],
+    f: &mut fmt::Formatter<'_>,
+    depth: usize,
+) -> fmt::Result {
     for term in term_list {
         display_depth(f, depth)?;
         display_term(term, f, depth)?;
@@ -1259,7 +1262,11 @@ fn display_terms(term_list: &[AmlTerm], f: &mut fmt::Formatter<'_>, depth: usize
     Ok(())
 }
 
-fn display_term_arg(term_arg: &TermArg, f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+pub(super) fn display_term_arg(
+    term_arg: &TermArg,
+    f: &mut fmt::Formatter<'_>,
+    depth: usize,
+) -> fmt::Result {
     match term_arg {
         TermArg::Expression(term) => display_term(term, f, depth),
         TermArg::DataObject(data) => match data {
@@ -1300,7 +1307,7 @@ fn display_target(target: &Target, f: &mut fmt::Formatter<'_>, depth: usize) -> 
     }
 }
 
-fn display_terms_list<'a>(
+pub(super) fn display_terms_list<'a>(
     terms: impl ExactSizeIterator<Item = &'a TermArg>,
     depth_divider: Option<usize>,
     f: &mut fmt::Formatter<'_>,
@@ -1390,7 +1397,11 @@ fn display_scope(scope: &ScopeObj, f: &mut fmt::Formatter<'_>, depth: usize) -> 
     writeln!(f, "}}")
 }
 
-fn display_method(method: &MethodObj, f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+pub(super) fn display_method(
+    method: &MethodObj,
+    f: &mut fmt::Formatter<'_>,
+    depth: usize,
+) -> fmt::Result {
     writeln!(f, "Method ({}, {}) {{", method.name, method.flags)?;
     display_terms(&method.term_list, f, depth + 1)?;
     display_depth(f, depth)?;
@@ -1411,7 +1422,7 @@ fn display_predicate_block(
     write!(f, "}}")
 }
 
-fn display_fields(
+pub(super) fn display_fields(
     fields: &[FieldElement],
     f: &mut fmt::Formatter<'_>,
     depth: usize,

--- a/kernel/src/acpi/aml/parser.rs
+++ b/kernel/src/acpi/aml/parser.rs
@@ -1520,7 +1520,7 @@ fn display_term(term: &AmlTerm, f: &mut fmt::Formatter<'_>, depth: usize) -> fmt
             writeln!(f, "}}")?;
         }
         AmlTerm::String(str) => {
-            write!(f, "\"{}\"", str)?;
+            write!(f, "\"{}\"", str.replace('\n', "\\n"))?;
         }
         AmlTerm::Method(method) => {
             display_method(method, f, depth)?;

--- a/kernel/src/acpi/aml/structured.rs
+++ b/kernel/src/acpi/aml/structured.rs
@@ -1,0 +1,404 @@
+use core::fmt;
+
+use alloc::{
+    collections::{btree_map::Entry, BTreeMap},
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+use tracing::warn;
+
+use super::{
+    parser::{
+        self, AmlTerm, FieldDef, IndexFieldDef, MethodObj, PowerResource, ProcessorDeprecated,
+        RegionObj, TermArg,
+    },
+    AmlCode,
+};
+
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct StructuredAml {
+    /// Denoted by `\`
+    root: Scope,
+}
+
+impl StructuredAml {
+    pub fn parse(code: &AmlCode) -> Self {
+        // We use `root` as a root reference, and `root_terms` that will be the scope
+        // of the root `code`, the reason we have two is that some statement use `\_SB` for example
+        // and some will just use `_SB` in the root, those are the same thing.
+        let mut root = Scope::default();
+        let root_terms = Scope::parse(&code.term_list, &mut root, "\\");
+
+        root.merge(root_terms);
+
+        Self { root }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ElementType {
+    ScopeOrDevice(Scope),
+    Method(MethodObj),
+    Processor(ProcessorDeprecated),
+    PowerResource(PowerResource),
+    RegionFields(Option<RegionObj>, Vec<FieldDef>),
+    IndexField(IndexFieldDef),
+    Name(TermArg),
+    Mutex(u8),
+    UnknownElements(Vec<AmlTerm>),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Scope {
+    children: BTreeMap<String, ElementType>,
+}
+
+impl Scope {
+    pub fn parse(terms: &[AmlTerm], root: &mut Scope, current_path: &str) -> Self {
+        let mut this = Scope::default();
+
+        fn handle_add(
+            current_path: &str,
+            this: &mut Scope,
+            root: &mut Scope,
+            name: &str,
+            element: ElementType,
+        ) {
+            if let Some(rest) = name.strip_prefix('\\') {
+                if rest.is_empty() {
+                    if let ElementType::ScopeOrDevice(scope) = element {
+                        root.merge(scope);
+                    } else {
+                        panic!("Root is not a scope or device");
+                    }
+                } else {
+                    root.add_child(rest, element);
+                }
+            } else if let Some(rest) = name.strip_prefix('^') {
+                assert!(!rest.is_empty());
+                // this will add to the parent
+                let (parent, _) = current_path.rsplit_once('.').expect("Must have parent");
+                assert!(
+                    parent.starts_with('\\'),
+                    "parent {parent:?} must start with \\"
+                );
+
+                if rest.starts_with('^') {
+                    // recurse
+                    handle_add(parent, this, root, rest, element);
+                } else {
+                    let full_path = format!("{}.{}", parent, rest);
+                    root.add_child(full_path.trim_start_matches('\\'), element);
+                }
+            } else {
+                this.add_child(name, element);
+            }
+        }
+
+        for term in terms {
+            match term {
+                AmlTerm::Device(scope) | AmlTerm::Scope(scope) => {
+                    let scope_path = if scope.name.starts_with('\\') {
+                        scope.name.clone()
+                    } else {
+                        format!(
+                            "{}{}{}",
+                            current_path,
+                            if current_path.ends_with('\\') {
+                                ""
+                            } else {
+                                "."
+                            },
+                            scope.name
+                        )
+                    };
+                    let element = ElementType::ScopeOrDevice(Scope::parse(
+                        &scope.term_list,
+                        root,
+                        &scope_path,
+                    ));
+                    handle_add(current_path, &mut this, root, &scope.name, element);
+                }
+                AmlTerm::Region(region) => {
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        &region.name,
+                        ElementType::RegionFields(Some(region.clone()), Vec::new()),
+                    );
+                }
+                AmlTerm::Field(field) => {
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        &field.name,
+                        ElementType::RegionFields(None, vec![field.clone()]),
+                    );
+                }
+                AmlTerm::IndexField(index_field) => {
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        &index_field.name,
+                        ElementType::IndexField(index_field.clone()),
+                    );
+                }
+                AmlTerm::Processor(processor) => {
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        &processor.name,
+                        ElementType::Processor(processor.clone()),
+                    );
+                }
+                AmlTerm::PowerResource(power_resource) => {
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        &power_resource.name,
+                        ElementType::PowerResource(power_resource.clone()),
+                    );
+                }
+                AmlTerm::Method(method) => {
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        &method.name,
+                        ElementType::Method(method.clone()),
+                    );
+                }
+                AmlTerm::NameObj(name, obj) => {
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        name,
+                        ElementType::Name(obj.clone()),
+                    );
+                }
+                AmlTerm::Mutex(name, num) => {
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        name,
+                        ElementType::Mutex(*num),
+                    );
+                }
+                _ => {
+                    warn!("Should not be in root terms {term:?}");
+                    handle_add(
+                        current_path,
+                        &mut this,
+                        root,
+                        "\\UNKW",
+                        ElementType::UnknownElements(vec![term.clone()]),
+                    );
+                }
+            }
+        }
+
+        this
+    }
+
+    // specific version for fast addition than `add_child`
+    fn add_immediate_child(&mut self, name: &str, element: ElementType) {
+        assert!(!name.starts_with('\\'));
+        assert_eq!(name.len(), 4, "Invalid name: {name:?}");
+        match self.children.entry(name.to_string()) {
+            Entry::Vacant(entry) => {
+                entry.insert(element);
+            }
+            Entry::Occupied(mut entry) => match entry.get_mut() {
+                ElementType::ScopeOrDevice(scope) => {
+                    let ElementType::ScopeOrDevice(element) = element else {
+                        panic!("New element: {name:?} is not a scope or device");
+                    };
+                    scope.merge(element);
+                }
+                ElementType::RegionFields(region, fields) => {
+                    let ElementType::RegionFields(new_region, new_fields) = element else {
+                        panic!("New element: {name:?} is not a region");
+                    };
+
+                    assert!(
+                        !(region.is_some() && new_region.is_some()),
+                        "Both regions are available, conflict, {region:?} && {new_region:?}"
+                    );
+                    *region = region.clone().or(new_region);
+                    fields.extend(new_fields);
+                }
+                ElementType::UnknownElements(elements) => {
+                    let ElementType::UnknownElements(new_elements) = element else {
+                        panic!("New element: {name:?} is not an unknown element");
+                    };
+                    elements.extend(new_elements);
+                }
+                _ => panic!("Child: {name:?} is not a scope or device"),
+            },
+        }
+    }
+
+    pub fn add_child(&mut self, name: &str, mut element: ElementType) {
+        assert!(!name.starts_with('\\'));
+        let split_result = name.split_once('.');
+
+        // change the name
+        match element {
+            ElementType::Method(ref mut method) => {
+                method.name = name.to_string();
+            }
+            ElementType::Processor(ref mut processor) => {
+                processor.name = name.to_string();
+            }
+            ElementType::PowerResource(ref mut power_resource) => {
+                power_resource.name = name.to_string();
+            }
+            ElementType::RegionFields(ref mut region, ref mut fields) => {
+                if let Some(r) = region.as_mut() {
+                    r.name = name.to_string();
+                }
+                for field in fields {
+                    field.name = name.to_string();
+                }
+            }
+            ElementType::IndexField(ref mut index_field) => {
+                index_field.name = name.to_string();
+            }
+            _ => {}
+        }
+
+        match split_result {
+            Some((first_child, rest)) => {
+                let child = self
+                    .children
+                    .entry(first_child.to_string())
+                    .or_insert(ElementType::ScopeOrDevice(Scope::default()));
+
+                if let ElementType::ScopeOrDevice(scope) = child {
+                    scope.add_child(rest, element);
+                } else {
+                    panic!(
+                        "Child: {first_child:?} of  {name:?} is not a scope or device {:?}",
+                        child
+                    );
+                }
+            }
+            None => {
+                self.add_immediate_child(name, element);
+            }
+        }
+    }
+
+    pub fn merge(&mut self, other: Scope) {
+        for (name, element) in other.children {
+            self.add_immediate_child(&name, element)
+        }
+    }
+}
+
+fn display_scope(
+    name: &str,
+    scope: &Scope,
+    f: &mut fmt::Formatter<'_>,
+    depth: usize,
+) -> fmt::Result {
+    writeln!(f, "Scope ({}) {{", name)?;
+    for (name, element) in &scope.children {
+        parser::display_depth(f, depth + 1)?;
+        match element {
+            ElementType::ScopeOrDevice(scope) => display_scope(name, scope, f, depth + 1)?,
+            ElementType::Method(method) => {
+                parser::display_method(method, f, depth + 1)?;
+            }
+            ElementType::Processor(processor) => {
+                writeln!(
+                    f,
+                    "Processor ({}, 0x{:02X}, 0x{:04X}, 0x{:02X}) {{",
+                    processor.name, processor.unk1, processor.unk2, processor.unk3
+                )?;
+                parser::display_terms(&processor.term_list, f, depth + 2)?;
+                parser::display_depth(f, depth + 1)?;
+                writeln!(f, "}}")?;
+            }
+            ElementType::PowerResource(power_resource) => {
+                writeln!(
+                    f,
+                    "PowerResource ({}, 0x{:02X}, 0x{:04X}) {{",
+                    power_resource.name, power_resource.system_level, power_resource.resource_order,
+                )?;
+                parser::display_terms(&power_resource.term_list, f, depth + 1)?;
+                parser::display_depth(f, depth)?;
+                writeln!(f, "}}")?;
+            }
+            ElementType::RegionFields(region, fields) => {
+                if let Some(region) = region {
+                    write!(f, "Region ({}, {}, ", region.name, region.region_space,)?;
+                    parser::display_term_arg(&region.region_offset, f, depth)?;
+                    write!(f, ", ")?;
+                    parser::display_term_arg(&region.region_length, f, depth)?;
+                    write!(f, ")")?;
+                } else {
+                    write!(f, "REGION {name:?} NOT FOUND!!!!")?;
+                }
+
+                writeln!(f)?;
+                if fields.is_empty() {
+                    write!(f, "NO FIELDS for {name:?} !!! ")?;
+                }
+                for field in fields {
+                    parser::display_depth(f, depth + 1)?;
+                    writeln!(f, "Field ({}, {}) {{", field.name, field.flags)?;
+                    parser::display_fields(&field.fields, f, depth + 2)?;
+                    parser::display_depth(f, depth + 1)?;
+                    writeln!(f, "}}")?;
+                }
+            }
+            ElementType::IndexField(index_field) => {
+                writeln!(
+                    f,
+                    "IndexField ({}, {}, {}) {{",
+                    index_field.name, index_field.index_name, index_field.flags
+                )?;
+                parser::display_fields(&index_field.fields, f, depth + 2)?;
+                parser::display_depth(f, depth + 1)?;
+                writeln!(f, "}}")?;
+            }
+            ElementType::Name(term) => {
+                write!(f, "Name({}, ", name)?;
+                parser::display_term_arg(term, f, depth + 1)?;
+                write!(f, ")")?;
+            }
+            ElementType::Mutex(sync_level) => {
+                write!(f, "Mutex ({}, {})", name, sync_level)?;
+            }
+            ElementType::UnknownElements(elements) => {
+                writeln!(f, "UnknownElements ({}) {{", name)?;
+                parser::display_terms(elements, f, depth + 2)?;
+                writeln!(f)?;
+                parser::display_depth(f, depth + 1)?;
+                write!(f, "}}")?;
+            }
+        }
+        writeln!(f)?;
+    }
+    parser::display_depth(f, depth)?;
+    writeln!(f, "}}")
+}
+
+impl StructuredAml {
+    #[allow(dead_code)]
+    pub fn display_with_depth(&self, f: &mut fmt::Formatter<'_>, depth: usize) -> fmt::Result {
+        parser::display_depth(f, depth)?;
+        display_scope("\\", &self.root, f, depth)
+    }
+}

--- a/kernel/src/cmdline.rs
+++ b/kernel/src/cmdline.rs
@@ -22,6 +22,7 @@ const fn default_cmdline() -> Cmd<'static> {
         max_log_level: LogLevel::Info,
         log_file: "/kernel.log",
         allow_hpet: true,
+        log_aml: false,
     }
 }
 
@@ -72,6 +73,9 @@ macros::cmdline_struct! {
         /// Allow `HPET` (if present), otherwise always use `PIT`
         #[default = true]
         pub allow_hpet: bool,
+        /// Log the AML content as ASL code on boot from ACPI tables
+        #[default = false]
+        pub log_aml: bool,
     }
 }
 


### PR DESCRIPTION
## Summary

Added a way to better structure AML code so that it will be easier to traverse and find labels.

It will store labels in a tree format, from something like

```txt
Scope (\) {
    Scope(_SB) {
        Method (LCRS) {...}
    }
}
Scope(\_SB) {
    Method (LDIS) {...}
}
```
will become instead

```txt
Scope (\) {
    Scope(_SB) {
        Method (LCRS) {...}
        Method (LDIS) {...}
    }
}
```

Also it will  be stored in a BTreeMap so finding children has small cost compared to going one by one

This will help to make it easier to execute 

### Related issue

Towards #38 


## Changes
- Add structured parser that will re-order the main scopes elements in AML
- Add `log_aml` cmdline that will be either `off`, `normal` (printed as parsed), `structured` (the re-structured code)
- Fix printing `\n` in AML strings
- Add `EisaId` macro parsing


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Tests if applicable (new features, regression tests, etc...)
- [x] Documentation
- [x] Needed README changes
