### PR TITLE
Aml execution

### DIFF
--- a/kernel/src/acpi/aml/execution.rs
+++ b/kernel/src/acpi/aml/execution.rs
@@ -1,0 +1,278 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use crate::{
+    acpi::aml::{parser::PackageElement, structured::ElementType},
+    testing,
+};
+
+use super::{
+    parser::{IntegerData, TermArg, UnresolvedDataObject},
+    structured::{StructuredAml, StructuredAmlError},
+};
+
+#[derive(Debug, Clone)]
+pub struct Package {
+    size: IntegerData,
+    elements: Vec<PackageElement<DataObject>>,
+}
+
+#[allow(dead_code)]
+impl Package {
+    pub fn size(&self) -> usize {
+        self.size.as_u64() as usize
+    }
+
+    pub fn get(&self, index: usize) -> Option<&PackageElement<DataObject>> {
+        self.elements.get(index)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &PackageElement<DataObject>> {
+        self.elements.iter()
+    }
+}
+
+/// A version of [UnresolvedDataObject] that is after execution
+/// so it doesn't have dynamic contents, references, or expressions
+#[derive(Debug, Clone)]
+pub enum DataObject {
+    Integer(IntegerData),
+    Buffer(IntegerData, Vec<u8>),
+    Package(Package),
+    String(String),
+    EisaId(String),
+}
+
+#[allow(dead_code)]
+impl DataObject {
+    pub fn as_integer(&self) -> Option<&IntegerData> {
+        match self {
+            Self::Integer(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    pub fn as_package(&self) -> Option<&Package> {
+        match self {
+            Self::Package(package) => Some(package),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AmlExecutionError {
+    LableNotFound(String),
+    StructuredAmlError(StructuredAmlError),
+    ElementNotExecutable(String),
+    UnexpectedTermResultType(TermArg, String),
+}
+
+impl From<StructuredAmlError> for AmlExecutionError {
+    fn from(err: StructuredAmlError) -> Self {
+        Self::StructuredAmlError(err)
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ExecutionContext {}
+impl ExecutionContext {
+    pub fn execute(
+        &self,
+        structured: &StructuredAml,
+        label: &str,
+        _args: &[UnresolvedDataObject],
+    ) -> Result<DataObject, AmlExecutionError> {
+        let element_to_execute = structured
+            .find_object(label)?
+            .ok_or(AmlExecutionError::LableNotFound(label.to_string()))?;
+
+        let data = match element_to_execute {
+            ElementType::Method(_) => todo!("Execute method"),
+            ElementType::Name(data) => data,
+            ElementType::UnknownElements(_) => {
+                // This label is internal and should never be reached
+                return Err(AmlExecutionError::LableNotFound(label.to_string()));
+            }
+            ElementType::PowerResource(_)
+            | ElementType::RegionFields(_, _)
+            | ElementType::IndexField(_)
+            | ElementType::Mutex(_)
+            | ElementType::ScopeOrDevice(_)
+            | ElementType::Processor(_) => {
+                return Err(AmlExecutionError::ElementNotExecutable(label.to_string()))
+            }
+        };
+
+        self.evaluate_data_object(data.clone(), label)
+    }
+
+    fn execute_term_arg(
+        &self,
+        term: &TermArg,
+        _reference_path: &str,
+    ) -> Result<DataObject, AmlExecutionError> {
+        todo!("Execute term: {:?}", term)
+    }
+
+    fn convert_package_elements(
+        &self,
+        elements: Vec<PackageElement<UnresolvedDataObject>>,
+        reference_path: &str,
+    ) -> Result<Vec<PackageElement<DataObject>>, AmlExecutionError> {
+        elements
+            .into_iter()
+            .map(|e| {
+                Ok(match e {
+                    PackageElement::DataObject(data) => {
+                        PackageElement::DataObject(self.evaluate_data_object(data, reference_path)?)
+                    }
+                    PackageElement::Name(name) => PackageElement::Name(name),
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn evaluate_data_object(
+        &self,
+        data: UnresolvedDataObject,
+        reference_path: &str,
+    ) -> Result<DataObject, AmlExecutionError> {
+        match data {
+            UnresolvedDataObject::Buffer(term, data) => {
+                let size_term = self.execute_term_arg(term.as_ref(), reference_path)?;
+
+                let size_term = match size_term {
+                    DataObject::Integer(i) => i,
+                    _ => {
+                        return Err(AmlExecutionError::UnexpectedTermResultType(
+                            term.as_ref().clone(),
+                            "Integer".to_string(),
+                        ))
+                    }
+                };
+
+                Ok(DataObject::Buffer(size_term, data.into_iter().collect()))
+            }
+            UnresolvedDataObject::Package(size, elements) => Ok(DataObject::Package(Package {
+                size: IntegerData::ByteConst(size),
+                elements: self.convert_package_elements(elements, reference_path)?,
+            })),
+            UnresolvedDataObject::VarPackage(term, elements) => {
+                let size_term = self.execute_term_arg(term.as_ref(), reference_path)?;
+
+                let size_term = match size_term {
+                    DataObject::Integer(i) => i,
+                    _ => {
+                        return Err(AmlExecutionError::UnexpectedTermResultType(
+                            term.as_ref().clone(),
+                            "Integer".to_string(),
+                        ))
+                    }
+                };
+
+                Ok(DataObject::Package(Package {
+                    size: size_term,
+                    elements: self.convert_package_elements(elements, reference_path)?,
+                }))
+            }
+            UnresolvedDataObject::Integer(i) => Ok(DataObject::Integer(i)),
+            UnresolvedDataObject::String(s) => Ok(DataObject::String(s)),
+            UnresolvedDataObject::EisaId(s) => Ok(DataObject::EisaId(s)),
+        }
+    }
+}
+
+testing::test! {
+    /// Test executing and getting data from
+    /// ```
+    /// Name("_S5_", Package(4) {0x5, 0x5, Zero, Zero}
+    /// Name("_S4_", Package(4) {0x4, 0x4, Zero, Zero}
+    /// ```
+    /// ```
+    fn test_execute_normal_sleep_package() {
+        use super::parser::{AmlCode, AmlTerm};
+        use alloc::vec;
+
+        fn return_package_of_name(
+            ctx: &mut ExecutionContext,
+            structured_code: &StructuredAml,
+            name: &str,
+        ) -> Vec<u8> {
+            ctx.execute(structured_code, name, &[])
+                .expect("label")
+                .as_package()
+                .expect("package")
+                .iter()
+                .map(|d| {
+                    d.as_data()
+                        .expect("data")
+                        .as_integer()
+                        .expect("integer")
+                        .as_u8()
+                        .unwrap()
+                })
+                .collect::<Vec<_>>()
+        }
+
+        let code = AmlCode {
+            term_list: vec![
+                AmlTerm::NameObj(
+                    "_S5_".to_string(),
+                    UnresolvedDataObject::Package(
+                        4,
+                        vec![
+                            PackageElement::DataObject(UnresolvedDataObject::Integer(
+                                IntegerData::ByteConst(5),
+                            )),
+                            PackageElement::DataObject(UnresolvedDataObject::Integer(
+                                IntegerData::ByteConst(5),
+                            )),
+                            PackageElement::DataObject(UnresolvedDataObject::Integer(
+                                IntegerData::ConstZero,
+                            )),
+                            PackageElement::DataObject(UnresolvedDataObject::Integer(
+                                IntegerData::ConstZero,
+                            )),
+                        ],
+                    ),
+                ),
+                AmlTerm::NameObj(
+                    "_S4_".to_string(),
+                    UnresolvedDataObject::Package(
+                        4,
+                        vec![
+                            PackageElement::DataObject(UnresolvedDataObject::Integer(
+                                IntegerData::ByteConst(4),
+                            )),
+                            PackageElement::DataObject(UnresolvedDataObject::Integer(
+                                IntegerData::ByteConst(4),
+                            )),
+                            PackageElement::DataObject(UnresolvedDataObject::Integer(
+                                IntegerData::ConstZero,
+                            )),
+                            PackageElement::DataObject(UnresolvedDataObject::Integer(
+                                IntegerData::ConstZero,
+                            )),
+                        ],
+                    ),
+                ),
+            ],
+        };
+
+        let structured_code = StructuredAml::parse(&code);
+
+        let mut execution_ctx = ExecutionContext::default();
+
+        assert_eq!(
+            return_package_of_name(&mut execution_ctx, &structured_code, "\\_S5_"),
+            vec![5, 5, 0, 0]
+        );
+        assert_eq!(
+            return_package_of_name(&mut execution_ctx, &structured_code, "\\_S4_"),
+            vec![4, 4, 0, 0]
+        );
+    }
+}

--- a/kernel/src/acpi/aml/mod.rs
+++ b/kernel/src/acpi/aml/mod.rs
@@ -1,5 +1,9 @@
+pub mod execution;
 mod parser;
 mod structured;
+
+use execution::{AmlExecutionError, DataObject, ExecutionContext};
+use parser::UnresolvedDataObject;
 
 pub use parser::{AmlCode, AmlParseError};
 use structured::StructuredAml;
@@ -28,5 +32,15 @@ impl Aml {
     #[allow(dead_code)]
     pub fn structured(&self) -> &StructuredAml {
         &self.structured
+    }
+
+    #[allow(dead_code)]
+    pub fn execute(
+        &self,
+        ctx: &mut ExecutionContext,
+        label: &str,
+        args: &[UnresolvedDataObject],
+    ) -> Result<DataObject, AmlExecutionError> {
+        ctx.execute(&self.structured, label, args)
     }
 }

--- a/kernel/src/acpi/aml/structured.rs
+++ b/kernel/src/acpi/aml/structured.rs
@@ -13,8 +13,8 @@ use crate::testing;
 
 use super::{
     parser::{
-        self, AmlTerm, FieldDef, IndexFieldDef, MethodObj, PowerResource, ProcessorDeprecated,
-        RegionObj, TermArg,
+        self, AmlTerm, DataObject, FieldDef, IndexFieldDef, MethodObj, PowerResource,
+        ProcessorDeprecated, RegionObj,
     },
     AmlCode,
 };
@@ -48,7 +48,7 @@ pub enum ElementType {
     PowerResource(PowerResource),
     RegionFields(Option<RegionObj>, Vec<FieldDef>),
     IndexField(IndexFieldDef),
-    Name(TermArg),
+    Name(DataObject),
     Mutex(u8),
     UnknownElements(Vec<AmlTerm>),
 }
@@ -375,9 +375,9 @@ fn display_scope(
                 parser::display_depth(f, depth + 1)?;
                 writeln!(f, "}}")?;
             }
-            ElementType::Name(term) => {
+            ElementType::Name(data_object) => {
                 write!(f, "Name({}, ", name)?;
-                parser::display_term_arg(term, f, depth + 1)?;
+                parser::display_data_object(data_object, f, depth + 1)?;
                 write!(f, ")")?;
             }
             ElementType::Mutex(sync_level) => {
@@ -407,7 +407,7 @@ impl StructuredAml {
 
 testing::test! {
     fn test_structure() {
-        use super::parser::{DataObject, FieldElement, IntegerData, ScopeObj, Target};
+        use super::parser::{DataObject, FieldElement, IntegerData, ScopeObj, Target, TermArg};
         use alloc::boxed::Box;
 
         let code = AmlCode {

--- a/kernel/src/acpi/aml/structured.rs
+++ b/kernel/src/acpi/aml/structured.rs
@@ -13,7 +13,7 @@ use crate::testing;
 
 use super::{
     parser::{
-        self, AmlTerm, DataObject, FieldDef, IndexFieldDef, MethodObj, PowerResource,
+        self, AmlTerm, UnresolvedDataObject, FieldDef, IndexFieldDef, MethodObj, PowerResource,
         ProcessorDeprecated, RegionObj,
     },
     AmlCode,
@@ -48,7 +48,7 @@ pub enum ElementType {
     PowerResource(PowerResource),
     RegionFields(Option<RegionObj>, Vec<FieldDef>),
     IndexField(IndexFieldDef),
-    Name(DataObject),
+    Name(UnresolvedDataObject),
     Mutex(u8),
     UnknownElements(Vec<AmlTerm>),
 }
@@ -407,7 +407,7 @@ impl StructuredAml {
 
 testing::test! {
     fn test_structure() {
-        use super::parser::{DataObject, FieldElement, IntegerData, ScopeObj, Target, TermArg};
+        use super::parser::{UnresolvedDataObject, FieldElement, IntegerData, ScopeObj, Target, TermArg};
         use alloc::boxed::Box;
 
         let code = AmlCode {
@@ -418,10 +418,10 @@ testing::test! {
                         AmlTerm::Region(RegionObj {
                             name: "DBG_".to_string(),
                             region_space: 1,
-                            region_offset: TermArg::DataObject(DataObject::Integer(
+                            region_offset: TermArg::DataObject(UnresolvedDataObject::Integer(
                                 IntegerData::WordConst(1026),
                             )),
-                            region_length: TermArg::DataObject(DataObject::Integer(
+                            region_length: TermArg::DataObject(UnresolvedDataObject::Integer(
                                 IntegerData::ConstOne,
                             )),
                         }),


### PR DESCRIPTION
## Summary

Add execution for AML, i.e. execute functions (still not implemented), and get named values.

This is very important to getting shutdown working using ACPI, since, to get shutdown working, we need to get the content of `\_Sx` objects, which is only available in AML.

### Related issue

<!-- Mention any relevant issues like #123 -->

Toward #38 


## Changes

<!-- Please provide some more detail regarding the changes.
Add any additional information, configuration, or data that might be necessary for the review
Mention the type of each change. i.e. `Addition`, `Bug Fix`, `Documentation`, etc... -->

- Several improvements to parsing AML
- Add execution for AML, currently, only can fetch named values, without "really" executing functions.
- A bit unrelated to this PR specifically, but improved the `test!` macro to be able to include docstrings


## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Tests if applicable (new features, regression tests, etc...)
- [ ] Documentation
- [ ] Needed README changes (no need)
