### PR TITLE
Improve displaying AML code using `fmt::Display` and Added more AML parsing

### DIFF
--- a/book/src/kernel/acpi/aml.md
+++ b/book/src/kernel/acpi/aml.md
@@ -9,8 +9,12 @@
 
 This is an `AML` parser that is able to parse the code inside the `DSDT` and `SSDT` tables.
 
-Currently, we do not use the parsed code, as we need to build an interpreter for it, so that we can emulate executing it
-and get the data we need.
+We have 2 forms of the parsed `AML`.
+- **Normal:** This is what we get from the table, we just parse it directly
+- **Structured:** After getting the `Normal` version, we do some processing to order them and group them by `Scope`
+  so that we can easily search for a given label.
+
+Any of these can be printed by the cmdline `log_aml` being `normal` or `structured` (See [Cmdline](../boot/cmdline.md))
 
 ## Why this is needed?
 

--- a/kernel/src/acpi/aml/display.rs
+++ b/kernel/src/acpi/aml/display.rs
@@ -179,3 +179,11 @@ impl<'a, 'b: 'a> AmlDisplayer<'a, 'b> {
         self.result
     }
 }
+
+pub struct HexHolder<'a, T: fmt::UpperHex>(pub &'a T);
+
+impl<T: fmt::UpperHex> fmt::Display for HexHolder<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#X}", self.0)
+    }
+}

--- a/kernel/src/acpi/aml/display.rs
+++ b/kernel/src/acpi/aml/display.rs
@@ -74,6 +74,7 @@ pub struct AmlDisplayer<'a, 'b: 'a> {
     result: fmt::Result,
     in_paren_arg: bool,
     already_in_paren_arg: bool,
+    already_in_body: bool,
     in_body: bool,
     is_list: bool,
 }
@@ -88,6 +89,7 @@ impl<'a, 'b: 'a> AmlDisplayer<'a, 'b> {
             already_in_paren_arg: false,
             in_body: false,
             is_list: false,
+            already_in_body: false,
         }
     }
 
@@ -159,7 +161,22 @@ impl<'a, 'b: 'a> AmlDisplayer<'a, 'b> {
         });
 
         self.in_body = true;
+        self.already_in_body = true;
 
+        self
+    }
+
+    pub fn at_least_empty_paren_arg(&mut self) -> &mut Self {
+        if !self.in_paren_arg && !self.already_in_paren_arg {
+            self.result = self.result.and_then(|_| self.fmt.write_str(" ()"));
+        }
+        self
+    }
+
+    pub fn at_least_empty_body(&mut self) -> &mut Self {
+        if !self.in_body && !self.already_in_body {
+            self.result = self.result.and_then(|_| self.fmt.write_str("{ }"));
+        }
         self
     }
 

--- a/kernel/src/acpi/aml/display.rs
+++ b/kernel/src/acpi/aml/display.rs
@@ -1,0 +1,181 @@
+use core::{
+    cell::RefCell,
+    fmt::{self, Write},
+};
+
+#[derive(Default)]
+struct PadAdapterState {
+    on_newline: bool,
+}
+
+struct PadAdapter<'buf, 'state> {
+    buf: &'buf mut (dyn fmt::Write + 'buf),
+    state: &'state mut PadAdapterState,
+}
+
+impl<'buf, 'state> PadAdapter<'buf, 'state> {
+    pub fn wrap(buf: &'buf mut dyn fmt::Write, state: &'state mut PadAdapterState) -> Self {
+        Self { buf, state }
+    }
+}
+
+impl fmt::Write for PadAdapter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for s in s.split_inclusive('\n') {
+            if self.state.on_newline {
+                self.buf.write_str("  ")?;
+            }
+
+            self.state.on_newline = s.ends_with('\n');
+            self.buf.write_str(s)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        if self.state.on_newline {
+            self.buf.write_str("  ")?;
+        }
+        self.state.on_newline = c == '\n';
+        self.buf.write_char(c)
+    }
+}
+
+struct FmtHolder<F>
+where
+    F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    f: RefCell<Option<F>>,
+}
+
+impl<F> FmtHolder<F>
+where
+    F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn new(value_fmt: F) -> Self {
+        Self {
+            f: RefCell::new(Some(value_fmt)),
+        }
+    }
+}
+
+impl<F> fmt::Display for FmtHolder<F>
+where
+    F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (self.f.borrow_mut().take().unwrap())(f)
+    }
+}
+
+pub struct AmlDisplayer<'a, 'b: 'a> {
+    fmt: &'a mut fmt::Formatter<'b>,
+    result: fmt::Result,
+    in_paren_arg: bool,
+    already_in_paren_arg: bool,
+    in_body: bool,
+    is_list: bool,
+}
+
+impl<'a, 'b: 'a> AmlDisplayer<'a, 'b> {
+    pub fn start(fmt: &'a mut fmt::Formatter<'b>, name: &str) -> Self {
+        let result = fmt.write_str(name);
+        Self {
+            fmt,
+            result,
+            in_paren_arg: false,
+            already_in_paren_arg: false,
+            in_body: false,
+            is_list: false,
+        }
+    }
+
+    pub fn set_list(&mut self, value: bool) -> &mut Self {
+        self.is_list = value;
+        self
+    }
+
+    pub fn paren_arg<F>(&mut self, value_fmt: F) -> &mut Self
+    where
+        F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+    {
+        if !self.in_paren_arg && self.already_in_paren_arg {
+            self.result = Err(fmt::Error);
+        }
+
+        self.result = self.result.and_then(|_| {
+            let prefix = if self.in_paren_arg { ", " } else { " ( " };
+
+            self.fmt.write_str(prefix)?;
+            value_fmt(self.fmt)
+        });
+
+        self.in_paren_arg = true;
+        self.already_in_paren_arg = true;
+
+        self
+    }
+
+    pub fn finish_paren_arg(&mut self) -> &mut Self {
+        if self.in_paren_arg {
+            self.result = self.result.and_then(|_| self.fmt.write_str(" )"));
+            self.in_paren_arg = false;
+        }
+        self
+    }
+
+    pub fn body_field<F>(&mut self, value_fmt: F) -> &mut Self
+    where
+        F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+    {
+        self.finish_paren_arg();
+
+        self.result = self.result.and_then(|_| {
+            if self.fmt.alternate() {
+                if !self.in_body {
+                    self.fmt.write_str(" {\n")?;
+                }
+
+                let mut state = PadAdapterState { on_newline: true };
+                let mut writer = PadAdapter::wrap(self.fmt, &mut state);
+                let fmt_holder = FmtHolder::new(value_fmt);
+                writer.write_fmt(format_args!("{:#}", fmt_holder))?;
+                writer.write_str(if self.is_list { ",\n" } else { "\n" })
+            } else {
+                let prefix = if self.in_body {
+                    if self.is_list {
+                        ", "
+                    } else {
+                        ";"
+                    }
+                } else {
+                    " { "
+                };
+
+                self.fmt.write_str(prefix)?;
+                value_fmt(self.fmt)
+            }
+        });
+
+        self.in_body = true;
+
+        self
+    }
+
+    pub fn finish(&mut self) -> fmt::Result {
+        self.finish_paren_arg();
+
+        if self.in_body {
+            self.result = self.result.and_then(|_| {
+                if !self.fmt.alternate() {
+                    self.fmt.write_str(" ")?;
+                }
+                self.fmt.write_str("}")
+            });
+            self.in_body = false;
+        }
+
+        self.result
+    }
+}

--- a/kernel/src/acpi/aml/execution.rs
+++ b/kernel/src/acpi/aml/execution.rs
@@ -99,7 +99,6 @@ impl ExecutionContext {
             ElementType::PowerResource(_)
             | ElementType::RegionFields(_, _)
             | ElementType::IndexField(_)
-            | ElementType::Mutex(_)
             | ElementType::ScopeOrDevice(_)
             | ElementType::Processor(_) => {
                 return Err(AmlExecutionError::ElementNotExecutable(label.to_string()))

--- a/kernel/src/acpi/aml/execution.rs
+++ b/kernel/src/acpi/aml/execution.rs
@@ -140,20 +140,23 @@ impl ExecutionContext {
         reference_path: &str,
     ) -> Result<DataObject, AmlExecutionError> {
         match data {
-            UnresolvedDataObject::Buffer(term, data) => {
-                let size_term = self.execute_term_arg(term.as_ref(), reference_path)?;
+            UnresolvedDataObject::Buffer(buffer) => {
+                let size_term = self.execute_term_arg(buffer.size.as_ref(), reference_path)?;
 
                 let size_term = match size_term {
                     DataObject::Integer(i) => i,
                     _ => {
                         return Err(AmlExecutionError::UnexpectedTermResultType(
-                            term.as_ref().clone(),
+                            buffer.size.as_ref().clone(),
                             "Integer".to_string(),
                         ))
                     }
                 };
 
-                Ok(DataObject::Buffer(size_term, data.into_iter().collect()))
+                Ok(DataObject::Buffer(
+                    size_term,
+                    buffer.data.into_iter().collect(),
+                ))
             }
             UnresolvedDataObject::Package(size, elements) => Ok(DataObject::Package(Package {
                 size: IntegerData::ByteConst(size),

--- a/kernel/src/acpi/aml/execution.rs
+++ b/kernel/src/acpi/aml/execution.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::{
-    parser::{IntegerData, TermArg, UnresolvedDataObject},
+    parser::{resource_template::ResourceTemplate, IntegerData, TermArg, UnresolvedDataObject},
     structured::{StructuredAml, StructuredAmlError},
 };
 
@@ -39,6 +39,7 @@ impl Package {
 #[derive(Debug, Clone)]
 pub enum DataObject {
     Integer(IntegerData),
+    ResourceTemplate(ResourceTemplate),
     Buffer(IntegerData, Vec<u8>),
     Package(Package),
     String(String),
@@ -157,6 +158,9 @@ impl ExecutionContext {
                     size_term,
                     buffer.data.into_iter().collect(),
                 ))
+            }
+            UnresolvedDataObject::ResourceTemplate(template) => {
+                Ok(DataObject::ResourceTemplate(template))
             }
             UnresolvedDataObject::Package(size, elements) => Ok(DataObject::Package(Package {
                 size: IntegerData::ByteConst(size),

--- a/kernel/src/acpi/aml/mod.rs
+++ b/kernel/src/acpi/aml/mod.rs
@@ -1,3 +1,4 @@
+mod display;
 pub mod execution;
 mod parser;
 mod structured;

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -3,9 +3,10 @@ use core::fmt;
 use crate::acpi::aml::display::AmlDisplayer;
 
 use super::{
-    AmlCode, AmlTerm, FieldAccessType, FieldDef, FieldElement, FieldUpdateRule, IndexFieldDef,
-    IntegerData, MethodObj, PackageElement, PowerResource, PredicateBlock, ProcessorDeprecated,
-    RegionObj, ScopeObj, Target, TermArg, UnresolvedDataObject,
+    AccessAttrib, AccessType, AmlCode, AmlTerm, Buffer, FieldConnection, FieldDef, FieldElement,
+    FieldUpdateRule, IndexFieldDef, IntegerData, MethodObj, PackageElement, PowerResource,
+    PredicateBlock, ProcessorDeprecated, RegionObj, RegionSpace, ScopeObj, Target, TermArg,
+    UnresolvedDataObject,
 };
 
 fn display_target_assign<F>(
@@ -176,32 +177,58 @@ impl fmt::Display for AccessType {
     }
 }
 
+impl fmt::Display for AccessAttrib {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AccessAttrib::ByteValue(v) => write!(f, "0x{:02X}", v),
+            AccessAttrib::Bytes(v) => write!(f, "AttribBytes ({})", v),
+            AccessAttrib::RawBytes(v) => write!(f, "AttribRawBytes ({})", v),
+            AccessAttrib::RawProcessBytes(v) => write!(f, "AttribRawProcessBytes ({})", v),
+            AccessAttrib::Quick => f.write_str("AttribQuick"),
+            AccessAttrib::SendRecv => f.write_str("AttribSendReceive"),
+            AccessAttrib::Byte => f.write_str("AttribByte"),
+            AccessAttrib::Word => f.write_str("AttribWord"),
+            AccessAttrib::Block => f.write_str("AttribBlock"),
+            AccessAttrib::ProcessCall => f.write_str("AttribProcessCall"),
+            AccessAttrib::BlockProcessCall => f.write_str("AttribBlockProcessCall"),
+        }
+    }
+}
+
 impl fmt::Display for FieldUpdateRule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
+impl fmt::Display for FieldConnection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FieldConnection::Buffer(buffer) => buffer.fmt(f),
+            FieldConnection::Name(name) => f.write_str(name),
+        }
+    }
+}
+
 impl fmt::Display for FieldElement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FieldElement::Reserved(len) => write!(f, "_Reserved (0x{:02X})", len),
+            FieldElement::Offset(offset) => write!(f, "Offset (0x{:02X})", offset),
             FieldElement::Named(name, len) => {
                 write!(
                     f,
-                    "{}, {}(0x{:02X})",
+                    "{}, {}{}",
                     name,
-                    if f.alternate() { "    " } else { "" },
+                    if f.alternate() { "  " } else { "" },
                     len
                 )
             }
             FieldElement::Access(access_type, access_attrib) => write!(
                 f,
-                "AccessAs {}(0x{:02X}, 0x{:02X})",
+                "AccessAs {}({access_type}, {access_attrib})",
                 if f.alternate() { " " } else { "" },
-                access_type,
-                access_attrib
             ),
+            FieldElement::Connection(connection) => write!(f, "{connection}"),
         }
     }
 }

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -5,8 +5,8 @@ use crate::acpi::aml::display::{AmlDisplayer, HexHolder};
 use super::{
     AccessAttrib, AccessType, AmlCode, AmlTerm, Buffer, FieldConnection, FieldDef, FieldElement,
     FieldUpdateRule, IndexFieldDef, IntegerData, MethodObj, PackageElement, PowerResource,
-    PredicateBlock, ProcessorDeprecated, RegionObj, RegionSpace, ScopeObj, Target, TermArg,
-    UnresolvedDataObject,
+    PredicateBlock, ProcessorDeprecated, RegionObj, RegionSpace, ScopeObj, ScopeType, Target,
+    TermArg, UnresolvedDataObject,
 };
 
 fn display_target_assign<F>(
@@ -84,7 +84,11 @@ impl fmt::Display for IndexFieldDef {
 
 impl fmt::Display for ScopeObj {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut d = AmlDisplayer::start(f, "Scope");
+        let ty = match self.ty {
+            ScopeType::Device => "Device",
+            ScopeType::Scope => "Scope",
+        };
+        let mut d = AmlDisplayer::start(f, ty);
         d.paren_arg(|f| f.write_str(&self.name)).finish_paren_arg();
         for term in &self.term_list {
             d.body_field(|f| term.fmt(f));

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -59,7 +59,7 @@ impl fmt::Display for FieldDef {
             d.body_field(|f| field.fmt(f));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }
 
@@ -78,7 +78,7 @@ impl fmt::Display for IndexFieldDef {
             d.body_field(|f| field.fmt(f));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }
 
@@ -94,7 +94,7 @@ impl fmt::Display for ScopeObj {
             d.body_field(|f| term.fmt(f));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }
 
@@ -111,7 +111,7 @@ impl fmt::Display for MethodObj {
                 })
             });
         if self.sync_level != 0 {
-            d.paren_arg(|f: &mut fmt::Formatter| write!(f, "0x{:X}", self.sync_level));
+            d.paren_arg(|f: &mut fmt::Formatter| write!(f, "0x{:02X}", self.sync_level));
         }
 
         d.finish_paren_arg();
@@ -120,7 +120,7 @@ impl fmt::Display for MethodObj {
             d.body_field(|f| term.fmt(f));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }
 
@@ -137,7 +137,7 @@ impl fmt::Display for ProcessorDeprecated {
             d.body_field(|f| term.fmt(f));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }
 
@@ -153,7 +153,7 @@ impl fmt::Display for PowerResource {
             d.body_field(|f| term.fmt(f));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }
 
@@ -166,7 +166,7 @@ impl fmt::Display for PredicateBlock {
             d.body_field(|f| term.fmt(f));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }
 
@@ -181,7 +181,7 @@ impl fmt::Display for Buffer {
             d.body_field(|f| write!(f, "0x{:02X}", element));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }
 
@@ -294,7 +294,7 @@ impl fmt::Display for UnresolvedDataObject {
             UnresolvedDataObject::ResourceTemplate(template) => template.fmt(f),
             UnresolvedDataObject::Package(size, elements) => {
                 let mut d = AmlDisplayer::start(f, "Package");
-                d.paren_arg(|f| write!(f, "0x{:X}", size))
+                d.paren_arg(|f| write!(f, "0x{:02X}", size))
                     .finish_paren_arg()
                     .set_list(true);
 
@@ -302,7 +302,7 @@ impl fmt::Display for UnresolvedDataObject {
                     d.body_field(|f| element.fmt(f));
                 }
 
-                d.finish()
+                d.at_least_empty_body().finish()
             }
             UnresolvedDataObject::VarPackage(size, elements) => {
                 let mut d = AmlDisplayer::start(f, "Package");
@@ -314,7 +314,7 @@ impl fmt::Display for UnresolvedDataObject {
                     d.body_field(|f| element.fmt(f));
                 }
 
-                d.finish()
+                d.at_least_empty_body().finish()
             }
             UnresolvedDataObject::String(str) => {
                 write!(f, "\"{}\"", str.replace('\n', "\\n"))
@@ -369,13 +369,13 @@ impl fmt::Display for AmlTerm {
             left: &dyn fmt::Display,
             right: &dyn fmt::Display,
         ) -> fmt::Result {
-            f.write_str("( ")?;
+            f.write_str("(")?;
             left.fmt(f)?;
             f.write_str(" ")?;
             f.write_str(op)?;
             f.write_str(" ")?;
             right.fmt(f)?;
-            f.write_str(" )")
+            f.write_str(")")
         }
 
         match self {
@@ -466,11 +466,11 @@ impl fmt::Display for AmlTerm {
                 f.write_str("--")
             }
             AmlTerm::While(predicate_block) => {
-                f.write_str("While ")?;
+                f.write_str("While")?;
                 predicate_block.fmt(f)
             }
             AmlTerm::If(predicate_block) => {
-                f.write_str("If ")?;
+                f.write_str("If")?;
                 predicate_block.fmt(f)
             }
             AmlTerm::Else(terms) => {
@@ -480,13 +480,13 @@ impl fmt::Display for AmlTerm {
                     d.body_field(|f| term.fmt(f));
                 }
 
-                d.finish()
+                d.at_least_empty_body().finish()
             }
             AmlTerm::Noop => f.write_str("Noop"),
             AmlTerm::Return(term) => {
-                f.write_str("Return ( ")?;
+                f.write_str("Return (")?;
                 term.fmt(f)?;
-                f.write_str(" )")
+                f.write_str(")")
             }
             AmlTerm::Break => f.write_str("Break"),
             AmlTerm::LAnd(term1, term2) => display_binary_op(f, "&&", term1, term2),

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -1,0 +1,522 @@
+use core::fmt;
+
+use crate::acpi::aml::display::AmlDisplayer;
+
+use super::{
+    AmlCode, AmlTerm, FieldAccessType, FieldDef, FieldElement, FieldUpdateRule, IndexFieldDef,
+    IntegerData, MethodObj, PackageElement, PowerResource, PredicateBlock, ProcessorDeprecated,
+    RegionObj, ScopeObj, Target, TermArg, UnresolvedDataObject,
+};
+
+fn display_target_assign<F>(
+    f: &mut fmt::Formatter<'_>,
+    target: &Target,
+    value_fmt: F,
+) -> fmt::Result
+where
+    F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    if !matches!(target, Target::None) {
+        fmt::Display::fmt(target, f)?;
+        f.write_str(" = ")?;
+    }
+
+    value_fmt(f)
+}
+
+impl fmt::Display for RegionObj {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        AmlDisplayer::start(f, "Region")
+            .paren_arg(|f| f.write_str(&self.name))
+            .paren_arg(|f| write!(f, "{:?}", self.region_space))
+            .paren_arg(|f| write!(f, "{}", self.region_offset))
+            .paren_arg(|f| write!(f, "{}", self.region_length))
+            .finish()
+    }
+}
+
+impl fmt::Display for FieldDef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "Field");
+        d.paren_arg(|f| f.write_str(&self.name))
+            .paren_arg(|f| write!(f, "{}", self.access_type))
+            .paren_arg(|f| write!(f, "{}", if self.need_lock { "Lock" } else { "NoLock" }))
+            .paren_arg(|f| write!(f, "{}", self.update_rule))
+            .finish_paren_arg()
+            .set_list(true);
+
+        for field in &self.fields {
+            d.body_field(|f| field.fmt(f));
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for IndexFieldDef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "IndexField");
+        d.paren_arg(|f| f.write_str(&self.index_name))
+            .paren_arg(|f| f.write_str(&self.name))
+            .paren_arg(|f| write!(f, "{}", self.access_type))
+            .paren_arg(|f| write!(f, "{}", if self.need_lock { "Lock" } else { "NoLock" }))
+            .paren_arg(|f| write!(f, "{}", self.update_rule))
+            .finish_paren_arg()
+            .set_list(true);
+
+        for field in &self.fields {
+            d.body_field(|f| field.fmt(f));
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for ScopeObj {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "Scope");
+        d.paren_arg(|f| f.write_str(&self.name)).finish_paren_arg();
+        for term in &self.term_list {
+            d.body_field(|f| term.fmt(f));
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for MethodObj {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "Method");
+        d.paren_arg(|f| f.write_str(&self.name))
+            .paren_arg(|f| self.flags.fmt(f))
+            .finish_paren_arg();
+
+        for term in &self.term_list {
+            d.body_field(|f| term.fmt(f));
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for ProcessorDeprecated {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "Processor");
+        d.paren_arg(|f| f.write_str(&self.name))
+            .paren_arg(|f| write!(f, "0x{:02X}", self.unk1))
+            .paren_arg(|f| write!(f, "0x{:08X}", self.unk2))
+            .paren_arg(|f| write!(f, "0x{:02X}", self.unk3))
+            .finish_paren_arg();
+
+        for term in &self.term_list {
+            d.body_field(|f| term.fmt(f));
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for PowerResource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "PowerResource");
+        d.paren_arg(|f| f.write_str(&self.name))
+            .paren_arg(|f| write!(f, "0x{:02X}", self.system_level))
+            .paren_arg(|f| write!(f, "0x{:04X}", self.resource_order))
+            .finish_paren_arg();
+
+        for term in &self.term_list {
+            d.body_field(|f| term.fmt(f));
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for PredicateBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "");
+        d.paren_arg(|f| self.predicate.fmt(f));
+
+        for term in &self.term_list {
+            d.body_field(|f| term.fmt(f));
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for FieldAccessType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)?;
+        f.write_str("Acc")
+    }
+}
+
+impl fmt::Display for FieldUpdateRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl fmt::Display for FieldElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FieldElement::Reserved(len) => write!(f, "_Reserved (0x{:02X})", len),
+            FieldElement::Named(name, len) => {
+                write!(
+                    f,
+                    "{}, {}(0x{:02X})",
+                    name,
+                    if f.alternate() { "    " } else { "" },
+                    len
+                )
+            }
+            FieldElement::Access(access_type, access_attrib) => write!(
+                f,
+                "AccessAs {}(0x{:02X}, 0x{:02X})",
+                if f.alternate() { " " } else { "" },
+                access_type,
+                access_attrib
+            ),
+        }
+    }
+}
+
+impl fmt::Display for TermArg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TermArg::Expression(term) => term.fmt(f),
+            TermArg::DataObject(dataobj) => dataobj.fmt(f),
+            TermArg::Arg(arg) => write!(f, "Arg{:x}", arg),
+            TermArg::Local(local) => write!(f, "Local{:x}", local),
+            TermArg::Name(name) => f.write_str(name),
+        }
+    }
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Target::None => write!(f, "None"),
+            Target::Arg(arg) => write!(f, "Arg{:x}", arg),
+            Target::Local(local) => write!(f, "Local{:x}", local),
+            Target::Name(name) => f.write_str(name),
+            Target::Debug => f.write_str("Debug"),
+            Target::DerefOf(term_arg) => AmlDisplayer::start(f, "DerefOf")
+                .paren_arg(|f| term_arg.fmt(f))
+                .finish(),
+            Target::RefOf(target) => AmlDisplayer::start(f, "RefOf")
+                .paren_arg(|f| target.fmt(f))
+                .finish(),
+            Target::Index(term_arg1, term_arg2, target) => {
+                display_target_assign(f, target.as_ref(), |f| {
+                    term_arg1.fmt(f)?;
+                    f.write_str("[")?;
+                    term_arg2.fmt(f)?;
+                    f.write_str("]")
+                })
+            }
+        }
+    }
+}
+
+impl fmt::Display for UnresolvedDataObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnresolvedDataObject::Integer(int) => int.fmt(f),
+            UnresolvedDataObject::Buffer(size, data) => {
+                let mut d = AmlDisplayer::start(f, "Buffer");
+                d.paren_arg(|f| size.fmt(f))
+                    .finish_paren_arg()
+                    .set_list(true);
+
+                for element in data {
+                    d.body_field(|f| write!(f, "0x{:02X}", element));
+                }
+
+                d.finish()
+            }
+            UnresolvedDataObject::Package(size, elements) => {
+                let mut d = AmlDisplayer::start(f, "Package");
+                d.paren_arg(|f| write!(f, "{:X}", size))
+                    .finish_paren_arg()
+                    .set_list(true);
+
+                for element in elements {
+                    d.body_field(|f| element.fmt(f));
+                }
+
+                d.finish()
+            }
+            UnresolvedDataObject::VarPackage(size, elements) => {
+                let mut d = AmlDisplayer::start(f, "Package");
+                d.paren_arg(|f| size.fmt(f))
+                    .finish_paren_arg()
+                    .set_list(true);
+
+                for element in elements {
+                    d.body_field(|f| element.fmt(f));
+                }
+
+                d.finish()
+            }
+            UnresolvedDataObject::String(str) => {
+                write!(f, "\"{}\"", str.replace('\n', "\\n"))
+            }
+            UnresolvedDataObject::EisaId(eisa_id) => write!(f, "EisaId ({:?})", eisa_id),
+        }
+    }
+}
+
+impl fmt::Display for IntegerData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IntegerData::ConstZero => write!(f, "Zero"),
+            IntegerData::ConstOne => write!(f, "One"),
+            IntegerData::ConstOnes => write!(f, "0xFFFFFFFFFFFFFFFF"),
+            IntegerData::ByteConst(data) => write!(f, "0x{:02X}", data),
+            IntegerData::WordConst(data) => write!(f, "0x{:04X}", data),
+            IntegerData::DWordConst(data) => write!(f, "0x{:08X}", data),
+            IntegerData::QWordConst(data) => write!(f, "0x{:016X}", data),
+        }
+    }
+}
+
+impl<D: fmt::Display> fmt::Display for PackageElement<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PackageElement::DataObject(dataobj) => dataobj.fmt(f),
+            PackageElement::Name(name) => f.write_str(name),
+        }
+    }
+}
+
+impl fmt::Display for AmlTerm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn display_func_like(
+            f: &mut fmt::Formatter<'_>,
+            name: &str,
+            elements: &[&dyn fmt::Display],
+        ) -> fmt::Result {
+            let mut d = AmlDisplayer::start(f, name);
+
+            for element in elements {
+                d.paren_arg(|f| element.fmt(f));
+            }
+
+            d.finish()
+        }
+
+        fn display_binary_op(
+            f: &mut fmt::Formatter<'_>,
+            op: &str,
+            left: &dyn fmt::Display,
+            right: &dyn fmt::Display,
+        ) -> fmt::Result {
+            f.write_str("( ")?;
+            left.fmt(f)?;
+            f.write_str(" ")?;
+            f.write_str(op)?;
+            f.write_str(" ")?;
+            right.fmt(f)?;
+            f.write_str(" )")
+        }
+
+        match self {
+            AmlTerm::Scope(scope) => scope.fmt(f),
+            AmlTerm::Region(region) => region.fmt(f),
+            AmlTerm::Field(field) => field.fmt(f),
+            AmlTerm::IndexField(field) => field.fmt(f),
+            AmlTerm::Device(scope) => scope.fmt(f),
+            AmlTerm::Processor(processor) => processor.fmt(f),
+            AmlTerm::PowerResource(resource) => resource.fmt(f),
+            AmlTerm::Method(method) => method.fmt(f),
+            AmlTerm::NameObj(name, object) => AmlDisplayer::start(f, "Name")
+                .paren_arg(|f| write!(f, "{}", name))
+                .paren_arg(|f| object.fmt(f))
+                .finish(),
+            AmlTerm::Alias(source, alias) => display_func_like(f, "Alias", &[source, alias]),
+            AmlTerm::ToHexString(term_arg, target) => {
+                display_func_like(f, "ToHexString", &[term_arg, target])
+            }
+            AmlTerm::ToBuffer(term_arg, target) => {
+                display_func_like(f, "ToBuffer", &[term_arg, target])
+            }
+            AmlTerm::ToDecimalString(term_arg, target) => {
+                display_func_like(f, "ToDecimalString", &[term_arg, target])
+            }
+            AmlTerm::ToInteger(term_arg, target) => {
+                display_func_like(f, "ToInteger", &[term_arg, target])
+            }
+            AmlTerm::Mid(term1, term2, term3, target) => {
+                display_func_like(f, "Mid", &[term1, term2, term3, target])
+            }
+            AmlTerm::Add(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "+", term1, term2))
+            }
+            AmlTerm::Concat(term1, term2, target) => {
+                display_func_like(f, "Concatenate", &[term1, term2, target])
+            }
+            AmlTerm::Subtract(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "-", term1, term2))
+            }
+            AmlTerm::Multiply(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "*", term1, term2))
+            }
+            AmlTerm::Divide(term1, term2, reminder, target) => {
+                if matches!(reminder.as_ref(), Target::None) {
+                    display_target_assign(f, target, |f| display_binary_op(f, "/", term1, term2))
+                } else {
+                    display_func_like(f, "Divide", &[term1, term2, reminder, target])
+                }
+            }
+            AmlTerm::ShiftLeft(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "<<", term1, term2))
+            }
+            AmlTerm::ShiftRight(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, ">>", term1, term2))
+            }
+            AmlTerm::And(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "&", term1, term2))
+            }
+            AmlTerm::Nand(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "~&", term1, term2))
+            }
+            AmlTerm::Or(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "|", term1, term2))
+            }
+            AmlTerm::Nor(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "~|", term1, term2))
+            }
+            AmlTerm::Xor(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "^", term1, term2))
+            }
+            AmlTerm::Not(term, target) => {
+                display_target_assign(f, target, |f| write!(f, "~{}", term))
+            }
+            AmlTerm::SizeOf(target) => display_func_like(f, "SizeOf", &[target]),
+            AmlTerm::Store(term_arg, target) => {
+                target.fmt(f)?;
+                f.write_str(" = ")?;
+                term_arg.fmt(f)
+            }
+            AmlTerm::RefOf(obj) => display_func_like(f, "RefOf", &[obj]),
+            AmlTerm::Increment(target) => {
+                target.fmt(f)?;
+                f.write_str("++")
+            }
+            AmlTerm::Decrement(target) => {
+                target.fmt(f)?;
+                f.write_str("--")
+            }
+            AmlTerm::While(predicate_block) => {
+                f.write_str("While ")?;
+                predicate_block.fmt(f)
+            }
+            AmlTerm::If(predicate_block) => {
+                f.write_str("If ")?;
+                predicate_block.fmt(f)
+            }
+            AmlTerm::Else(terms) => {
+                f.write_str("Else ")?;
+                let mut d = AmlDisplayer::start(f, "");
+                for term in terms {
+                    d.body_field(|f| term.fmt(f));
+                }
+
+                d.finish()
+            }
+            AmlTerm::Noop => f.write_str("Noop"),
+            AmlTerm::Return(term) => {
+                f.write_str("Return ")?;
+                term.fmt(f)
+            }
+            AmlTerm::Break => f.write_str("Break"),
+            AmlTerm::LAnd(term1, term2) => display_binary_op(f, "&&", term1, term2),
+            AmlTerm::LOr(term1, term2) => display_binary_op(f, "||", term1, term2),
+            AmlTerm::LNot(term) => {
+                write!(f, "!{}", term)
+            }
+            AmlTerm::LNotEqual(term1, term2) => display_binary_op(f, "!=", term1, term2),
+            AmlTerm::LLessEqual(term1, term2) => display_binary_op(f, "<=", term1, term2),
+            AmlTerm::LGreaterEqual(term1, term2) => display_binary_op(f, ">=", term1, term2),
+            AmlTerm::LEqual(term1, term2) => display_binary_op(f, "==", term1, term2),
+            AmlTerm::LGreater(term1, term2) => display_binary_op(f, ">", term1, term2),
+            AmlTerm::LLess(term1, term2) => display_binary_op(f, "<", term1, term2),
+            AmlTerm::FindSetLeftBit(term, target) => {
+                display_func_like(f, "FindSetLeftBit", &[term, target])
+            }
+            AmlTerm::FindSetRightBit(term, target) => {
+                display_func_like(f, "FindSetRightBit", &[term, target])
+            }
+            AmlTerm::DerefOf(term_arg) => display_func_like(f, "DerefOf", &[term_arg]),
+            AmlTerm::ConcatRes(term1, term2, target) => {
+                display_func_like(f, "ConcatenateResTemplate", &[term1, term2, target])
+            }
+            AmlTerm::Mod(term1, term2, target) => {
+                display_target_assign(f, target, |f| display_binary_op(f, "%", term1, term2))
+            }
+            AmlTerm::Notify(target, term_arg) => {
+                display_func_like(f, "Notify", &[target, term_arg])
+            }
+            AmlTerm::Index(term1, term2, target) => display_target_assign(f, target, |f| {
+                term1.fmt(f)?;
+                write!(f, "[")?;
+                term2.fmt(f)?;
+                write!(f, "]")
+            }),
+            AmlTerm::Mutex(name, num) => {
+                write!(f, "Mutex({name}, 0x{num:02X})")
+            }
+            AmlTerm::Event(name) => display_func_like(f, "Event", &[name]),
+            AmlTerm::CondRefOf(src, dest) => display_func_like(f, "CondRefOf", &[src, dest]),
+            AmlTerm::CreateFieldOp(src, bit_index, num_bits, field_name) => {
+                display_func_like(f, "CreateFieldOp", &[src, bit_index, num_bits, field_name])
+            }
+            AmlTerm::Acquire(target, num) => {
+                // TODO: display number in hex, using maybe custom struct
+                display_func_like(f, "Acquire", &[target, num])
+            }
+            AmlTerm::Signal(target) => display_func_like(f, "Signal", &[target]),
+            AmlTerm::Wait(target, term) => display_func_like(f, "Wait", &[target, term]),
+            AmlTerm::Reset(target) => display_func_like(f, "Reset", &[target]),
+            AmlTerm::Release(target) => display_func_like(f, "Release", &[target]),
+            AmlTerm::Stall(term_arg) => display_func_like(f, "Stall", &[term_arg]),
+            AmlTerm::Sleep(term_arg) => display_func_like(f, "Sleep", &[term_arg]),
+            AmlTerm::CreateDWordField(term1, term2, name) => {
+                display_func_like(f, "CreateDWordField", &[term1, term2, name])
+            }
+            AmlTerm::CreateWordField(term1, term2, name) => {
+                display_func_like(f, "CreateWordField", &[term1, term2, name])
+            }
+            AmlTerm::CreateByteField(term1, term2, name) => {
+                display_func_like(f, "CreateByteField", &[term1, term2, name])
+            }
+            AmlTerm::CreateBitField(term1, term2, name) => {
+                display_func_like(f, "CreateBitField", &[term1, term2, name])
+            }
+            AmlTerm::CreateQWordField(term1, term2, name) => {
+                display_func_like(f, "CreateQWordField", &[term1, term2, name])
+            }
+            AmlTerm::MethodCall(name, args) => {
+                let mut d = AmlDisplayer::start(f, name);
+
+                for arg in args {
+                    d.paren_arg(|f| arg.fmt(f));
+                }
+
+                d.finish()
+            }
+            AmlTerm::ObjectType(obj) => display_func_like(f, "ObjectType", &[obj]),
+        }
+    }
+}
+
+impl fmt::Display for AmlCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for term in &self.term_list {
+            term.fmt(f)?;
+        }
+        Ok(())
+    }
+}

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -24,9 +24,18 @@ where
     value_fmt(f)
 }
 
+impl fmt::Display for RegionSpace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Other(x) => write!(f, "0x{:02X}", x),
+            _ => write!(f, "{:?}", self),
+        }
+    }
+}
+
 impl fmt::Display for RegionObj {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        AmlDisplayer::start(f, "Region")
+        AmlDisplayer::start(f, "OperationRegion")
             .paren_arg(|f| f.write_str(&self.name))
             .paren_arg(|f| write!(f, "{:?}", self.region_space))
             .paren_arg(|f| write!(f, "{}", self.region_offset))

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -291,6 +291,7 @@ impl fmt::Display for UnresolvedDataObject {
         match self {
             UnresolvedDataObject::Integer(int) => int.fmt(f),
             UnresolvedDataObject::Buffer(buffer) => buffer.fmt(f),
+            UnresolvedDataObject::ResourceTemplate(template) => template.fmt(f),
             UnresolvedDataObject::Package(size, elements) => {
                 let mut d = AmlDisplayer::start(f, "Package");
                 d.paren_arg(|f| write!(f, "0x{:X}", size))

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -554,8 +554,16 @@ impl fmt::Display for AmlTerm {
 
 impl fmt::Display for AmlCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for term in &self.term_list {
+        for (i, term) in self.term_list.iter().enumerate() {
             term.fmt(f)?;
+
+            if i < self.term_list.len() - 1 {
+                if f.alternate() {
+                    writeln!(f)?;
+                } else {
+                    write!(f, "; ")?;
+                }
+            }
         }
         Ok(())
     }

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -154,7 +154,22 @@ impl fmt::Display for PredicateBlock {
     }
 }
 
-impl fmt::Display for FieldAccessType {
+impl fmt::Display for Buffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "Buffer");
+        d.paren_arg(|f| self.size.fmt(f))
+            .finish_paren_arg()
+            .set_list(true);
+
+        for element in self.data.iter() {
+            d.body_field(|f| write!(f, "0x{:02X}", element));
+        }
+
+        d.finish()
+    }
+}
+
+impl fmt::Display for AccessType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)?;
         f.write_str("Acc")
@@ -233,18 +248,7 @@ impl fmt::Display for UnresolvedDataObject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             UnresolvedDataObject::Integer(int) => int.fmt(f),
-            UnresolvedDataObject::Buffer(size, data) => {
-                let mut d = AmlDisplayer::start(f, "Buffer");
-                d.paren_arg(|f| size.fmt(f))
-                    .finish_paren_arg()
-                    .set_list(true);
-
-                for element in data {
-                    d.body_field(|f| write!(f, "0x{:02X}", element));
-                }
-
-                d.finish()
-            }
+            UnresolvedDataObject::Buffer(buffer) => buffer.fmt(f),
             UnresolvedDataObject::Package(size, elements) => {
                 let mut d = AmlDisplayer::start(f, "Package");
                 d.paren_arg(|f| write!(f, "{:X}", size))

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -98,8 +98,19 @@ impl fmt::Display for MethodObj {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = AmlDisplayer::start(f, "Method");
         d.paren_arg(|f| f.write_str(&self.name))
-            .paren_arg(|f| self.flags.fmt(f))
-            .finish_paren_arg();
+            .paren_arg(|f| write!(f, "{}", self.num_args))
+            .paren_arg(|f| {
+                f.write_str(if self.is_serialized {
+                    "Serialized"
+                } else {
+                    "NotSerialized"
+                })
+            });
+        if self.sync_level != 0 {
+            d.paren_arg(|f: &mut fmt::Formatter| write!(f, "0x{:X}", self.sync_level));
+        }
+
+        d.finish_paren_arg();
 
         for term in &self.term_list {
             d.body_field(|f| term.fmt(f));

--- a/kernel/src/acpi/aml/parser/display.rs
+++ b/kernel/src/acpi/aml/parser/display.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::acpi::aml::display::AmlDisplayer;
+use crate::acpi::aml::display::{AmlDisplayer, HexHolder};
 
 use super::{
     AccessAttrib, AccessType, AmlCode, AmlTerm, Buffer, FieldConnection, FieldDef, FieldElement,
@@ -289,7 +289,7 @@ impl fmt::Display for UnresolvedDataObject {
             UnresolvedDataObject::Buffer(buffer) => buffer.fmt(f),
             UnresolvedDataObject::Package(size, elements) => {
                 let mut d = AmlDisplayer::start(f, "Package");
-                d.paren_arg(|f| write!(f, "{:X}", size))
+                d.paren_arg(|f| write!(f, "0x{:X}", size))
                     .finish_paren_arg()
                     .set_list(true);
 
@@ -479,8 +479,9 @@ impl fmt::Display for AmlTerm {
             }
             AmlTerm::Noop => f.write_str("Noop"),
             AmlTerm::Return(term) => {
-                f.write_str("Return ")?;
-                term.fmt(f)
+                f.write_str("Return ( ")?;
+                term.fmt(f)?;
+                f.write_str(" )")
             }
             AmlTerm::Break => f.write_str("Break"),
             AmlTerm::LAnd(term1, term2) => display_binary_op(f, "&&", term1, term2),
@@ -526,7 +527,7 @@ impl fmt::Display for AmlTerm {
             }
             AmlTerm::Acquire(target, num) => {
                 // TODO: display number in hex, using maybe custom struct
-                display_func_like(f, "Acquire", &[target, num])
+                display_func_like(f, "Acquire", &[target, &HexHolder(num)])
             }
             AmlTerm::Signal(target) => display_func_like(f, "Signal", &[target]),
             AmlTerm::Wait(target, term) => display_func_like(f, "Wait", &[target, term]),

--- a/kernel/src/acpi/aml/parser/mod.rs
+++ b/kernel/src/acpi/aml/parser/mod.rs
@@ -248,9 +248,46 @@ impl ScopeObj {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
+#[allow(non_camel_case_types)]
+pub enum RegionSpace {
+    SystemMemory,
+    SystemIO,
+    PCI_Config,
+    EmbeddedControl,
+    SMBus,
+    SystemCMOS,
+    PciBarTarget,
+    IPMI,
+    GeneralPurposeIO,
+    GenericSerialBus,
+    PCC,
+    Other(u8),
+}
+
+impl From<u8> for RegionSpace {
+    fn from(space: u8) -> Self {
+        match space {
+            0 => Self::SystemMemory,
+            1 => Self::SystemIO,
+            2 => Self::PCI_Config,
+            3 => Self::EmbeddedControl,
+            4 => Self::SMBus,
+            5 => Self::SystemCMOS,
+            6 => Self::PciBarTarget,
+            7 => Self::IPMI,
+            8 => Self::GeneralPurposeIO,
+            9 => Self::GenericSerialBus,
+            10 => Self::PCC,
+            _ => Self::Other(space),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct RegionObj {
     pub(super) name: String,
-    pub(super) region_space: u8,
+    pub(super) region_space: RegionSpace,
     pub(super) region_offset: TermArg,
     pub(super) region_length: TermArg,
 }
@@ -259,7 +296,7 @@ impl RegionObj {
     fn parse(parser: &mut Parser) -> Result<Self, AmlParseError> {
         let name = parser.parse_name()?;
         trace!("region name: {}", name);
-        let region_space = parser.get_next_byte()?;
+        let region_space = parser.get_next_byte()?.into();
         let region_offset = parser.parse_term_arg()?;
         trace!("region offset: {:?}", region_offset);
         let region_length = parser.parse_term_arg()?;

--- a/kernel/src/acpi/aml/parser/mod.rs
+++ b/kernel/src/acpi/aml/parser/mod.rs
@@ -26,6 +26,8 @@ pub enum AmlParseError {
     InvalidFieldUpdateRule,
     ReservedFieldSet,
     ResourceTemplateReservedTag,
+    ReservedValue,
+    InvalidResourceTemplate,
 }
 
 pub fn parse_aml(code: &[u8]) -> Result<AmlCode, AmlParseError> {

--- a/kernel/src/acpi/aml/parser/mod.rs
+++ b/kernel/src/acpi/aml/parser/mod.rs
@@ -99,7 +99,7 @@ impl IntegerData {
 #[derive(Debug, Clone)]
 pub enum UnresolvedDataObject {
     Integer(IntegerData),
-    Buffer(Box<TermArg>, Vec<u8>),
+    Buffer(Buffer),
     Package(u8, Vec<PackageElement<UnresolvedDataObject>>),
     VarPackage(Box<TermArg>, Vec<PackageElement<UnresolvedDataObject>>),
     String(String),
@@ -129,6 +129,12 @@ impl<T> PackageElement<T> {
             _ => None,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct Buffer {
+    pub(super) size: Box<TermArg>,
+    pub(super) data: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]
@@ -1158,7 +1164,10 @@ impl Parser<'_> {
                 let mut inner = self.get_inner_parser()?;
                 let buf_size = inner.parse_term_arg()?;
                 // no need for `check_empty`, just take all remaining
-                UnresolvedDataObject::Buffer(Box::new(buf_size), inner.code[inner.pos..].to_vec())
+                UnresolvedDataObject::Buffer(Buffer {
+                    size: Box::new(buf_size),
+                    data: inner.code[inner.pos..].to_vec(),
+                })
             }
             0x12 => {
                 let mut inner = self.get_inner_parser()?;

--- a/kernel/src/acpi/aml/parser/resource_template.rs
+++ b/kernel/src/acpi/aml/parser/resource_template.rs
@@ -1,0 +1,856 @@
+use core::fmt;
+
+use alloc::vec::Vec;
+
+use crate::{acpi::aml::display::AmlDisplayer, io::ByteStr};
+
+use super::{AccessType, AmlParseError, Buffer, RegionSpace};
+
+#[allow(dead_code)]
+mod consts {
+    pub const END_TAG_FULL: u8 = 0x79;
+}
+
+pub struct Parser<'a> {
+    buffer: &'a [u8],
+    pos: usize,
+}
+
+impl Parser<'_> {
+    pub fn get_next_byte(&mut self) -> Result<u8, AmlParseError> {
+        if self.pos >= self.buffer.len() {
+            return Err(AmlParseError::UnexpectedEndOfCode);
+        }
+        let byte = self.buffer[self.pos];
+        self.pos += 1;
+        Ok(byte)
+    }
+
+    pub fn get_next_u16(&mut self) -> Result<u16, AmlParseError> {
+        let low = self.get_next_byte()? as u16;
+        let high = self.get_next_byte()? as u16;
+
+        Ok((high << 8) | low)
+    }
+
+    pub fn get_next_u32(&mut self) -> Result<u32, AmlParseError> {
+        Ok(u32::from_le_bytes([
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+        ]))
+    }
+
+    pub fn get_next_u64(&mut self) -> Result<u64, AmlParseError> {
+        Ok(u64::from_le_bytes([
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+            self.get_next_byte()?,
+        ]))
+    }
+
+    pub fn get_data_as_slice(&mut self, len: usize) -> Result<&[u8], AmlParseError> {
+        if self.pos + len > self.buffer.len() {
+            return Err(AmlParseError::UnexpectedEndOfCode);
+        }
+
+        let slice = &self.buffer[self.pos..self.pos + len];
+        self.pos += len;
+        Ok(slice)
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.pos >= self.buffer.len()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DmaSpeedType {
+    Compatibility,
+    TypeA,
+    TypeB,
+    TypeF,
+}
+
+#[derive(Debug, Clone)]
+pub enum DmaTrasferType {
+    Transfer8,
+    Transfer16,
+    Transfer8_16,
+}
+
+#[derive(Debug, Clone)]
+#[allow(clippy::enum_variant_names)]
+pub enum DmaTransferWidth {
+    Width8Bit,
+    Width16Bit,
+    Width32Bit,
+    Width64Bit,
+    Width128Bit,
+    Width256Bit,
+}
+
+#[derive(Debug, Clone)]
+pub enum ResourceMacro {
+    Irq {
+        wake_capable: bool,
+        is_shared: bool,
+        active_low: bool,
+        edge_triggered: bool,
+        irqs_mask: u16,
+    },
+    Dma {
+        speed_ty: DmaSpeedType,
+        is_bus_master: bool,
+        transfer_type: DmaTrasferType,
+        channels_mask: u8,
+    },
+    StartDependentFunctions {
+        compatibility_priority: u8,
+        performance_priority: u8,
+    },
+    EndDependentFunctions,
+    Io {
+        is_16_bit_decode: bool,
+        min_addr: u16,
+        max_addr: u16,
+        alignment: u8,
+        len: u8,
+    },
+    FixedIo {
+        base: u16,
+        len: u8,
+    },
+    FixedDma {
+        dma_req: u16,
+        channel: u16,
+        transfer_width: DmaTransferWidth,
+    },
+    VendorShort {
+        data: [u8; 6],
+        len: u8,
+    },
+    VendorLarge {
+        data: Vec<u8>,
+    },
+    Memory24 {
+        is_read_write: bool,
+        min_addr: u32,
+        max_addr: u32,
+        alignment: u16,
+        len: u16,
+    },
+    Memory32Fixed {
+        is_read_write: bool,
+        base_addr: u32,
+        len: u32,
+    },
+    Memory32 {
+        is_read_write: bool,
+        min_addr: u32,
+        max_addr: u32,
+        alignment: u32,
+        len: u32,
+    },
+    Interrupt {
+        is_consumer: bool,
+        edge_triggered: bool,
+        active_low: bool,
+        is_shared: bool,
+        wake_capable: bool,
+        interrupts: Vec<u32>,
+        resource_source_index: Option<u8>,
+        resource_source: Option<Vec<u8>>,
+    },
+    Register {
+        address_space: RegionSpace,
+        bit_width: u8,
+        offset: u8,
+        address: u64,
+        access_size: AccessType,
+    },
+}
+
+impl ResourceMacro {
+    fn try_parse_small_resource(
+        parser: &mut Parser,
+        first: u8,
+    ) -> Result<Option<Self>, AmlParseError> {
+        let result = match first {
+            0x22 | 0x23 => {
+                // contain extra 1 byte
+                let contain_info = first == 0x23;
+
+                let irqs_mask = parser.get_next_u16()?;
+
+                let mut wake_capable = false;
+                let mut is_shared = false;
+                let mut active_low = false;
+                let mut edge_triggered = true;
+
+                if contain_info {
+                    let flags = parser.get_next_byte()?;
+                    edge_triggered = flags & 1 != 0;
+                    active_low = flags & (1 << 3) != 0;
+                    is_shared = flags & (1 << 4) != 0;
+                    wake_capable = flags & (1 << 5) != 0;
+
+                    if flags & (0b11 << 6) != 0 {
+                        return Err(AmlParseError::ReservedFieldSet);
+                    }
+                }
+
+                Some(ResourceMacro::Irq {
+                    wake_capable,
+                    is_shared,
+                    active_low,
+                    edge_triggered,
+                    irqs_mask,
+                })
+            }
+            0x2A => {
+                // DMA
+                let channels_mask = parser.get_next_byte()?;
+                let flags = parser.get_next_byte()?;
+
+                if flags & 0x80 != 0 {
+                    return Err(AmlParseError::ReservedFieldSet);
+                }
+
+                let transfer_type = match flags & 0b11 {
+                    0b00 => DmaTrasferType::Transfer8,
+                    0b01 => DmaTrasferType::Transfer8_16,
+                    0b10 => DmaTrasferType::Transfer16,
+                    _ => return Err(AmlParseError::ReservedFieldSet),
+                };
+                let is_bus_master = (flags >> 2) & 1 == 1;
+                let speed_ty = match (flags >> 5) & 0b11 {
+                    0b00 => DmaSpeedType::Compatibility,
+                    0b01 => DmaSpeedType::TypeA,
+                    0b10 => DmaSpeedType::TypeB,
+                    0b11 => DmaSpeedType::TypeF,
+                    _ => unreachable!(),
+                };
+
+                Some(ResourceMacro::Dma {
+                    speed_ty,
+                    is_bus_master,
+                    transfer_type,
+                    channels_mask,
+                })
+            }
+            0x30 | 0x31 => {
+                let contain_priority_byte = first == 0x31;
+
+                let mut compatibility_priority = 1;
+                let mut performance_priority = 1;
+
+                if contain_priority_byte {
+                    let flags = parser.get_next_byte()?;
+                    compatibility_priority = flags & 0b11;
+                    performance_priority = (flags >> 2) & 0b11;
+
+                    if flags & (0b1111 << 4) != 0 {
+                        return Err(AmlParseError::ReservedFieldSet);
+                    }
+                }
+
+                Some(ResourceMacro::StartDependentFunctions {
+                    compatibility_priority,
+                    performance_priority,
+                })
+            }
+            0x38 => Some(ResourceMacro::EndDependentFunctions),
+            0x47 => {
+                let flags = parser.get_next_byte()?;
+                let min_addr = parser.get_next_u16()?;
+                let max_addr = parser.get_next_u16()?;
+                let alignment = parser.get_next_byte()?;
+                let len = parser.get_next_byte()?;
+
+                Some(ResourceMacro::Io {
+                    is_16_bit_decode: flags & 1 == 1,
+                    min_addr,
+                    max_addr,
+                    alignment,
+                    len,
+                })
+            }
+            0x4B => {
+                let base = parser.get_next_u16()? & 0x3FF;
+                let len = parser.get_next_byte()?;
+
+                Some(ResourceMacro::FixedIo { base, len })
+            }
+            0x55 => {
+                let dma_req = parser.get_next_u16()?;
+                let channel = parser.get_next_u16()?;
+
+                let transfer_width = match parser.get_next_byte()? {
+                    0 => DmaTransferWidth::Width8Bit,
+                    1 => DmaTransferWidth::Width16Bit,
+                    2 => DmaTransferWidth::Width32Bit,
+                    3 => DmaTransferWidth::Width64Bit,
+                    4 => DmaTransferWidth::Width128Bit,
+                    5 => DmaTransferWidth::Width256Bit,
+                    _ => return Err(AmlParseError::ReservedFieldSet),
+                };
+
+                Some(ResourceMacro::FixedDma {
+                    dma_req,
+                    channel,
+                    transfer_width,
+                })
+            }
+            0x71..=0x77 => {
+                let len = (first & 0b111) - 1;
+
+                let mut data = [0; 6];
+
+                for d in data.iter_mut().take(len as usize) {
+                    *d = parser.get_next_byte()?;
+                }
+
+                Some(ResourceMacro::VendorShort { data, len })
+            }
+            0x79 => {
+                return Err(AmlParseError::ResourceTemplateReservedTag);
+            }
+            _ => None,
+        };
+
+        Ok(result)
+    }
+
+    fn try_parse_large_resource(
+        parser: &mut Parser,
+        first: u8,
+    ) -> Result<Option<Self>, AmlParseError> {
+        if first & 0x80 != 0x80 {
+            return Ok(None);
+        }
+
+        let data_len = parser.get_next_u16()?;
+
+        let result = match first & 0x7F {
+            0x00 | 0x03 | 0x13..=0x7F => {
+                return Err(AmlParseError::ResourceTemplateReservedTag);
+            }
+            0x01 => {
+                assert_eq!(data_len, 9);
+                let flags = parser.get_next_byte()?;
+
+                let min_addr = parser.get_next_u16()?;
+                let max_addr = parser.get_next_u16()?;
+                let alignment = parser.get_next_u16()?;
+                let len = parser.get_next_u16()?;
+
+                Some(ResourceMacro::Memory24 {
+                    is_read_write: flags & 1 == 1,
+                    min_addr: (min_addr as u32) << 8,
+                    max_addr: (max_addr as u32) << 8,
+                    alignment,
+                    len,
+                })
+            }
+            0x02 => {
+                assert_eq!(data_len, 12);
+                let mut address_space = parser.get_next_byte()?.into();
+
+                if let RegionSpace::Other(other) = address_space {
+                    if other == 0x7F {
+                        address_space = RegionSpace::FFixedHW;
+                    } else {
+                        return Err(AmlParseError::ReservedFieldSet);
+                    }
+                }
+                let bit_width = parser.get_next_byte()?;
+                let offset = parser.get_next_byte()?;
+                let access_size = parser.get_next_byte()?.try_into()?;
+                let address = parser.get_next_u64()?;
+
+                if let AccessType::Buffer = access_size {
+                    return Err(AmlParseError::ReservedFieldSet);
+                }
+
+                Some(ResourceMacro::Register {
+                    address_space,
+                    bit_width,
+                    offset,
+                    address,
+                    access_size,
+                })
+            }
+            0x04 => {
+                let data = parser.get_data_as_slice(data_len as usize)?;
+
+                Some(ResourceMacro::VendorLarge {
+                    data: data.to_vec(),
+                })
+            }
+            0x05 => {
+                assert_eq!(data_len, 17);
+                let flags = parser.get_next_byte()?;
+
+                let min_addr = parser.get_next_u32()?;
+                let max_addr = parser.get_next_u32()?;
+                let alignment = parser.get_next_u32()?;
+                let len = parser.get_next_u32()?;
+
+                Some(ResourceMacro::Memory32 {
+                    is_read_write: flags & 1 == 1,
+                    min_addr,
+                    max_addr,
+                    alignment,
+                    len,
+                })
+            }
+            0x06 => {
+                assert_eq!(data_len, 9);
+                let flags = parser.get_next_byte()?;
+
+                let base_addr = parser.get_next_u32()?;
+                let len = parser.get_next_u32()?;
+
+                Some(ResourceMacro::Memory32Fixed {
+                    is_read_write: flags & 1 == 1,
+                    base_addr,
+                    len,
+                })
+            }
+            0x09 => {
+                let flags = parser.get_next_byte()?;
+                let is_consumed = flags & 1 != 0;
+                let edge_triggered = flags & (1 << 1) != 0;
+                let active_low = flags & (1 << 2) != 0;
+                let is_shared = flags & (1 << 3) != 0;
+                let wake_capable = flags & (1 << 4) != 0;
+
+                let table_len = parser.get_next_byte()?;
+
+                let mut interrupts = Vec::with_capacity(table_len as usize);
+                for _ in 0..table_len {
+                    interrupts.push(parser.get_next_u32()?);
+                }
+
+                let mut len_so_far = table_len as u16 * 4 + 2;
+                let resource_source_index = if len_so_far < data_len {
+                    Some(parser.get_next_byte()?)
+                } else {
+                    None
+                };
+                len_so_far += 1;
+
+                let resource_source = if len_so_far < data_len {
+                    let buffer =
+                        parser.get_data_as_slice(data_len as usize - len_so_far as usize)?;
+                    Some(buffer.to_vec())
+                } else {
+                    None
+                };
+                Some(ResourceMacro::Interrupt {
+                    is_consumer: is_consumed,
+                    edge_triggered,
+                    active_low,
+                    is_shared,
+                    wake_capable,
+                    interrupts,
+                    resource_source_index,
+                    resource_source,
+                })
+            }
+            0x0A => {
+                assert_eq!(data_len, 43);
+
+                todo!()
+            }
+            _ => None,
+        };
+
+        Ok(result)
+    }
+
+    pub fn try_parse_buffer(parser: &mut Parser) -> Result<Option<Self>, AmlParseError> {
+        let first = parser.get_next_byte()?;
+
+        if let Some(result) = Self::try_parse_small_resource(parser, first)? {
+            return Ok(Some(result));
+        };
+
+        Self::try_parse_large_resource(parser, first)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ResourceTemplate {
+    pub(super) items: Vec<ResourceMacro>,
+}
+
+impl ResourceTemplate {
+    pub fn try_parse_buffer(buf: &Buffer) -> Result<Option<Self>, AmlParseError> {
+        let data = buf.data.as_slice();
+        // is this a resource template anyway?
+        {
+            if data.len() < 2 || data[data.len() - 2] != consts::END_TAG_FULL {
+                return Ok(None);
+            }
+
+            let sum: u8 = buf.data.iter().fold(0, |a, b| a.wrapping_add(*b));
+            // The checksum must match or the last element can be 0
+            if sum != 0 && data.last() != Some(&0) {
+                return Ok(None);
+            }
+        }
+
+        let data = &data[0..buf.data.len() - 2];
+
+        let mut parser = Parser {
+            buffer: data,
+            pos: 0,
+        };
+
+        let mut items = Vec::new();
+        while !parser.is_done() {
+            let Some(item) = ResourceMacro::try_parse_buffer(&mut parser)? else {
+                return Ok(None);
+            };
+
+            items.push(item);
+        }
+
+        Ok(Some(ResourceTemplate { items }))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn display_interrupt_args<'a, 'b, 'r>(
+    d: &'r mut AmlDisplayer<'a, 'b>,
+    is_consumer: Option<bool>,
+    wake_capable: bool,
+    is_shared: bool,
+    active_low: bool,
+    edge_triggered: bool,
+    resource_source_index: Option<u8>,
+    resource_source: Option<&Vec<u8>>,
+) -> &'r mut AmlDisplayer<'a, 'b> {
+    if let Some(is_consumer) = is_consumer {
+        d.paren_arg(|f| {
+            f.write_str(if is_consumer {
+                "ResourceConsumer"
+            } else {
+                "ResourceProducer"
+            })
+        });
+    }
+
+    d.paren_arg(|f| f.write_str(if edge_triggered { "Edge" } else { "Level" }))
+        .paren_arg(|f| {
+            f.write_str(if active_low {
+                "ActiveLow"
+            } else {
+                "ActiveHigh"
+            })
+        })
+        .paren_arg(|f| {
+            f.write_str(if is_shared { "Shared" } else { "Exclusive" })?;
+            if wake_capable {
+                f.write_str("WakeCapable")
+            } else {
+                Ok(())
+            }
+        });
+    if let Some(resource_source_index) = resource_source_index {
+        d.paren_arg(|f| write!(f, "{}", resource_source_index));
+    }
+    if let Some(resource_source) = resource_source {
+        d.paren_arg(|f| write!(f, "{:?}", ByteStr(resource_source)));
+    }
+
+    d
+}
+
+trait NumHexDisplay {
+    fn fmt_hex(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
+}
+
+impl NumHexDisplay for u8 {
+    fn fmt_hex(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{:02X}", self)
+    }
+}
+
+impl NumHexDisplay for u16 {
+    fn fmt_hex(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{:04X}", self)
+    }
+}
+
+impl NumHexDisplay for u32 {
+    fn fmt_hex(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{:08X}", self)
+    }
+}
+
+impl NumHexDisplay for u64 {
+    fn fmt_hex(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{:016X}", self)
+    }
+}
+
+fn display_memory_args<'a, 'b>(
+    f: &'a mut fmt::Formatter<'b>,
+    name: &str,
+    is_read_write: bool,
+    nums: &[&dyn NumHexDisplay],
+) -> AmlDisplayer<'a, 'b> {
+    let mut d = AmlDisplayer::start(f, name);
+
+    d.paren_arg(|f| {
+        f.write_str(if is_read_write {
+            "ReadWrite"
+        } else {
+            "ReadOnce"
+        })
+    });
+
+    for num in nums {
+        d.paren_arg(|f| num.fmt_hex(f));
+    }
+
+    d
+}
+
+impl fmt::Display for DmaSpeedType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl fmt::Display for DmaTrasferType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl fmt::Display for DmaTransferWidth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl fmt::Display for ResourceMacro {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ResourceMacro::Irq {
+                wake_capable,
+                is_shared,
+                active_low,
+                edge_triggered,
+                irqs_mask,
+            } => {
+                let mut d = AmlDisplayer::start(f, "IRQ");
+                display_interrupt_args(
+                    &mut d,
+                    None,
+                    *wake_capable,
+                    *is_shared,
+                    *active_low,
+                    *edge_triggered,
+                    None,
+                    None,
+                )
+                .finish_paren_arg();
+
+                for i in 0..15 {
+                    if irqs_mask & (1 << i) != 0 {
+                        d.body_field(|f| write!(f, "{}", i));
+                    }
+                }
+
+                d.at_least_empty_body().finish()
+            }
+            ResourceMacro::Dma {
+                speed_ty,
+                is_bus_master,
+                transfer_type,
+                channels_mask,
+            } => {
+                let mut d = AmlDisplayer::start(f, "DMA");
+                d.paren_arg(|f| speed_ty.fmt(f))
+                    .paren_arg(|f| {
+                        f.write_str(if *is_bus_master {
+                            "BusMaster"
+                        } else {
+                            "NotBusMaster"
+                        })
+                    })
+                    .paren_arg(|f| transfer_type.fmt(f));
+
+                for i in 0..7 {
+                    if channels_mask & (1 << i) != 0 {
+                        d.body_field(|f| write!(f, "{}", i));
+                    }
+                }
+
+                d.at_least_empty_body().finish()
+            }
+            // TODO: this is not correct, it should have a list of terms inside it, but meh, do it later
+            ResourceMacro::StartDependentFunctions {
+                compatibility_priority,
+                performance_priority,
+            } => AmlDisplayer::start(f, "StartDependentFn")
+                .paren_arg(|f| write!(f, "{}", compatibility_priority))
+                .paren_arg(|f| write!(f, "{}", performance_priority))
+                .finish(),
+            ResourceMacro::EndDependentFunctions => AmlDisplayer::start(f, "EndDependentFn")
+                .at_least_empty_paren_arg()
+                .finish(),
+            ResourceMacro::Io {
+                is_16_bit_decode,
+                min_addr,
+                max_addr,
+                alignment,
+                len,
+            } => AmlDisplayer::start(f, "IO")
+                .paren_arg(|f| {
+                    f.write_str(if *is_16_bit_decode {
+                        "Decode16"
+                    } else {
+                        "Decode10"
+                    })
+                })
+                .paren_arg(|f| write!(f, "0x{:04X}", min_addr))
+                .paren_arg(|f| write!(f, "0x{:04X}", max_addr))
+                .paren_arg(|f| write!(f, "0x{:02X}", alignment))
+                .paren_arg(|f| write!(f, "0x{:02X}", len))
+                .finish(),
+            ResourceMacro::FixedIo { base, len } => AmlDisplayer::start(f, "FixedIO")
+                .paren_arg(|f| write!(f, "0x{:04X}", base))
+                .paren_arg(|f| write!(f, "0x{:02X}", len))
+                .finish(),
+            ResourceMacro::FixedDma {
+                dma_req,
+                channel,
+                transfer_width,
+            } => AmlDisplayer::start(f, "FixedDMA")
+                .paren_arg(|f| write!(f, "0x{:04X}", dma_req))
+                .paren_arg(|f| write!(f, "0x{:04X}", channel))
+                .paren_arg(|f| transfer_width.fmt(f))
+                .finish(),
+            ResourceMacro::VendorShort { data, len } => {
+                let mut d = AmlDisplayer::start(f, "VendorShort");
+                d.at_least_empty_paren_arg();
+
+                for e in data.iter().take(*len as usize) {
+                    d.body_field(|f| write!(f, "0x{:02X}", e));
+                }
+
+                d.finish()
+            }
+            ResourceMacro::VendorLarge { data } => {
+                let mut d = AmlDisplayer::start(f, "VendorLarge");
+                d.at_least_empty_paren_arg();
+
+                for e in data {
+                    d.body_field(|f| write!(f, "0x{:02X}", e));
+                }
+
+                d.finish()
+            }
+            ResourceMacro::Memory24 {
+                is_read_write,
+                min_addr,
+                max_addr,
+                alignment,
+                len,
+            } => display_memory_args(
+                f,
+                "Memory24",
+                *is_read_write,
+                &[min_addr, max_addr, alignment, len],
+            )
+            .finish(),
+            ResourceMacro::Memory32Fixed {
+                is_read_write,
+                base_addr,
+                len,
+            } => {
+                display_memory_args(f, "Memory32Fixed", *is_read_write, &[base_addr, len]).finish()
+            }
+            ResourceMacro::Memory32 {
+                is_read_write,
+                min_addr,
+                max_addr,
+                alignment,
+                len,
+            } => display_memory_args(
+                f,
+                "Memory32",
+                *is_read_write,
+                &[min_addr, max_addr, alignment, len],
+            )
+            .finish(),
+            ResourceMacro::Interrupt {
+                is_consumer,
+                edge_triggered,
+                active_low,
+                is_shared,
+                wake_capable,
+                interrupts,
+                resource_source_index,
+                resource_source,
+            } => {
+                let mut d = AmlDisplayer::start(f, "Interrupt");
+                display_interrupt_args(
+                    &mut d,
+                    Some(*is_consumer),
+                    *wake_capable,
+                    *is_shared,
+                    *active_low,
+                    *edge_triggered,
+                    *resource_source_index,
+                    resource_source.as_ref(),
+                )
+                .finish_paren_arg();
+
+                for i in interrupts {
+                    d.body_field(|f| write!(f, "0x{:08X}", i));
+                }
+
+                d.at_least_empty_body().finish()
+            }
+            ResourceMacro::Register {
+                address_space,
+                bit_width,
+                offset,
+                address,
+                access_size,
+            } => AmlDisplayer::start(f, "Register")
+                .paren_arg(|f| address_space.fmt(f))
+                .paren_arg(|f| write!(f, "0x{:02X}", bit_width))
+                .paren_arg(|f| write!(f, "0x{:02X}", offset))
+                .paren_arg(|f| write!(f, "0x{:08X}", address))
+                .paren_arg(|f| write!(f, "{}", access_size.clone() as u8))
+                .finish(),
+        }
+    }
+}
+
+impl fmt::Display for ResourceTemplate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = AmlDisplayer::start(f, "ResourceTemplate");
+        d.at_least_empty_paren_arg();
+
+        for item in &self.items {
+            d.body_field(|f| item.fmt(f));
+        }
+
+        d.finish()
+    }
+}

--- a/kernel/src/acpi/aml/parser/resource_template.rs
+++ b/kernel/src/acpi/aml/parser/resource_template.rs
@@ -919,7 +919,7 @@ fn display_memory_args<'a, 'b>(
         f.write_str(if is_read_write {
             "ReadWrite"
         } else {
-            "ReadOnce"
+            "ReadOnly"
         })
     });
 
@@ -989,7 +989,7 @@ impl<W: AddressWidth> fmt::Display for AddressSpace<W> {
         let mut d = AmlDisplayer::start(f, "");
 
         if let AddressSpaceType::VendorDefined { value, .. } = self.ty {
-            d.paren_arg(|f| write!(f, "0x{:X}", value));
+            d.paren_arg(|f| write!(f, "0x{:02X}", value));
         }
         d.paren_arg(|f| {
             f.write_str(if self.is_consumer {
@@ -1030,7 +1030,7 @@ impl<W: AddressWidth> fmt::Display for AddressSpace<W> {
                 d.paren_arg(write_decode);
                 d.paren_arg(write_min_fixed);
                 d.paren_arg(write_max_fixed);
-                d.paren_arg(|f| write!(f, "0x{:X}", flags));
+                d.paren_arg(|f| write!(f, "0x{:02X}", flags));
             }
         }
 
@@ -1129,7 +1129,8 @@ impl fmt::Display for ResourceMacro {
                     *edge_triggered,
                     &ResourceSource::empty(),
                 )
-                .finish_paren_arg();
+                .finish_paren_arg()
+                .set_list(true);
 
                 for i in 0..15 {
                     if irqs_mask & (1 << i) != 0 {
@@ -1154,7 +1155,9 @@ impl fmt::Display for ResourceMacro {
                             "NotBusMaster"
                         })
                     })
-                    .paren_arg(|f| transfer_type.fmt(f));
+                    .paren_arg(|f| transfer_type.fmt(f))
+                    .finish_paren_arg()
+                    .set_list(true);
 
                 for i in 0..7 {
                     if channels_mask & (1 << i) != 0 {
@@ -1209,23 +1212,23 @@ impl fmt::Display for ResourceMacro {
                 .finish(),
             ResourceMacro::VendorShort { data, len } => {
                 let mut d = AmlDisplayer::start(f, "VendorShort");
-                d.at_least_empty_paren_arg();
+                d.at_least_empty_paren_arg().set_list(true);
 
                 for e in data.iter().take(*len as usize) {
                     d.body_field(|f| write!(f, "0x{:02X}", e));
                 }
 
-                d.finish()
+                d.at_least_empty_body().finish()
             }
             ResourceMacro::VendorLarge { data } => {
                 let mut d = AmlDisplayer::start(f, "VendorLarge");
-                d.at_least_empty_paren_arg();
+                d.at_least_empty_paren_arg().set_list(true);
 
                 for e in data {
                     d.body_field(|f| write!(f, "0x{:02X}", e));
                 }
 
-                d.finish()
+                d.at_least_empty_body().finish()
             }
             ResourceMacro::Memory24 {
                 is_read_write,
@@ -1279,7 +1282,8 @@ impl fmt::Display for ResourceMacro {
                     *edge_triggered,
                     resource_source,
                 )
-                .finish_paren_arg();
+                .finish_paren_arg()
+                .set_list(true);
 
                 for i in interrupts {
                     d.body_field(|f| write!(f, "0x{:08X}", i));
@@ -1317,6 +1321,6 @@ impl fmt::Display for ResourceTemplate {
             d.body_field(|f| item.fmt(f));
         }
 
-        d.finish()
+        d.at_least_empty_body().finish()
     }
 }

--- a/kernel/src/acpi/aml/structured.rs
+++ b/kernel/src/acpi/aml/structured.rs
@@ -444,7 +444,7 @@ testing::test! {
     fn test_structure() {
         use super::parser::{
             FieldAccessType, FieldElement, FieldUpdateRule, IntegerData, ScopeObj, Target, TermArg,
-            UnresolvedDataObject,
+            UnresolvedDataObject, RegionSpace
         };
         use alloc::boxed::Box;
 
@@ -455,7 +455,7 @@ testing::test! {
                     term_list: vec![
                         AmlTerm::Region(RegionObj {
                             name: "DBG_".to_string(),
-                            region_space: 1,
+                            region_space: RegionSpace::SystemIO,
                             region_offset: TermArg::DataObject(UnresolvedDataObject::Integer(
                                 IntegerData::WordConst(1026),
                             )),

--- a/kernel/src/acpi/aml/structured.rs
+++ b/kernel/src/acpi/aml/structured.rs
@@ -480,7 +480,9 @@ testing::test! {
                         }),
                         AmlTerm::Method(MethodObj {
                             name: "DBUG".to_string(),
-                            flags: 1,
+                            num_args: 1,
+                            is_serialized: false,
+                            sync_level: 0,
                             term_list: vec![
                                 AmlTerm::ToHexString(TermArg::Arg(0), Box::new(Target::Local(0))),
                                 AmlTerm::ToBuffer(TermArg::Local(0), Box::new(Target::Local(0))),
@@ -490,7 +492,9 @@ testing::test! {
                 }),
                 AmlTerm::Method(MethodObj {
                     name: "\\_GPE._E02".to_string(),
-                    flags: 0,
+                    num_args: 0,
+                    is_serialized: false,
+                    sync_level: 0,
                     term_list: vec![AmlTerm::MethodCall("\\_SB_.CPUS.CSCN".to_string(), vec![])],
                 }),
             ],

--- a/kernel/src/acpi/aml/structured.rs
+++ b/kernel/src/acpi/aml/structured.rs
@@ -451,7 +451,7 @@ impl fmt::Display for StructuredAml {
 testing::test! {
     fn test_structure() {
         use super::parser::{
-            FieldAccessType, FieldElement, FieldUpdateRule, IntegerData, ScopeObj, Target, TermArg,
+            AccessType, FieldElement, FieldUpdateRule, IntegerData, ScopeObj, Target, TermArg,
             UnresolvedDataObject, RegionSpace
         };
         use alloc::boxed::Box;
@@ -473,7 +473,7 @@ testing::test! {
                         }),
                         AmlTerm::Field(FieldDef {
                             name: "DBG_".to_string(),
-                            access_type: FieldAccessType::Byte,
+                            access_type: AccessType::Byte,
                             need_lock: false,
                             update_rule: FieldUpdateRule::Preserve,
                             fields: vec![FieldElement::Named("DBGB".to_string(), 8)],

--- a/kernel/src/acpi/aml/structured.rs
+++ b/kernel/src/acpi/aml/structured.rs
@@ -405,7 +405,7 @@ impl fmt::Display for Scope {
 
                     d.body_field(|f| scope.fmt(f));
 
-                    d.finish()
+                    d.at_least_empty_body().finish()
                 }
                 ElementType::Method(method) => method.fmt(f),
                 ElementType::Processor(processor) => processor.fmt(f),
@@ -451,7 +451,7 @@ impl fmt::Display for Scope {
                         d.body_field(|f| element.fmt(f));
                     }
 
-                    d.finish()
+                    d.at_least_empty_body().finish()
                 }
             }?;
 

--- a/kernel/src/acpi/aml/structured.rs
+++ b/kernel/src/acpi/aml/structured.rs
@@ -392,8 +392,16 @@ impl fmt::Display for Scope {
                         write!(f, "; ")?;
                     }
 
-                    for field in fields {
+                    for (i, field) in fields.iter().enumerate() {
                         field.fmt(f)?;
+
+                        if i < fields.len() - 1 {
+                            if f.alternate() {
+                                writeln!(f)?;
+                            } else {
+                                write!(f, "; ")?;
+                            }
+                        }
                     }
 
                     Ok(())

--- a/kernel/src/acpi/tables/mod.rs
+++ b/kernel/src/acpi/tables/mod.rs
@@ -680,12 +680,10 @@ impl fmt::Display for BiosTables {
 
                     match cmdline::cmdline().log_aml {
                         LogAml::Normal => {
-                            writeln!(f, "AML: ")?;
-                            data.aml.code().display_with_depth(f, 1)?;
+                            writeln!(f, "AML: \n{:#}", data.aml.code())?;
                         }
                         LogAml::Structured => {
-                            writeln!(f, "AML: ")?;
-                            data.aml.structured().display_with_depth(f, 1)?;
+                            writeln!(f, "AML: \n{:#}", data.aml.structured())?;
                         }
                         LogAml::Off => {}
                     }


### PR DESCRIPTION
## Summary

<!-- Please provide a brief description of the changes made in this PR -->

I copied parts of how `DebugStruct` is implemented in the `std` library in rust. Because we needed to have some kind of recursive structure.

And also added parsing for `ResourceTemplate` macros, and other structs

### Related issue

<!-- Mention any relevant issues like #123 -->
None, it was just to make AML better


## Changes

<!-- Please provide some more detail regarding the changes.
Add any additional information, configuration, or data that might be necessary for the review
Mention the type of each change. i.e. `Addition`, `Bug Fix`, `Documentation`, etc... -->

- Improve printing of `AML` code using `fmt::Display`, design inspired (copied) from `DebugStruct` in `rust` `std`
- Fix parsing of `flags` field in `FieldDef` and `IndexFieldDef`
- Improve parsing for `OperationRegion`
- Improve parsing for `Method` and added the flags it uses and so on
- Added parsing for `ResourceTemplate` macros, most are available except [Connection descriptors](https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/06_Device_Configuration/Device_Configuration.html#connection-descriptors)
- Fixed `Device` being printed as `Scope`

## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [ ] Tests if applicable (new features, regression tests, etc...)
       (created #115 for this :smile:, too lazy to add it here)
- [x] Documentation
- [x] Needed README changes (no need)
