### PR TITLE
ICMP and IPv4 support

### DIFF
--- a/book/src/kernel/boot/cmdline.md
+++ b/book/src/kernel/boot/cmdline.md
@@ -22,19 +22,19 @@ last value will be used.
 > This is implemented in [`cmdline`][kernel_cmdline]
 > implemented as
 > ```rust
-> cmdline_struct! {
->     pub struct Cmd<'a> {
->         #[default = true]
->         pub uart: bool,
->         #[default = 115200]
->         pub uart_baud: u32,
->         #[default = LogLevel::Info]
->         pub max_log_level: LogLevel,
->         #[default = "/kernel.log"]
->         pub log_file: &'a str,
->         #[default = true]
->         pub allow_hpet: bool,
->     }
+> pub struct Cmd<'a> {
+>     #[default = true]
+>     pub uart: bool,
+>     #[default = 115200]
+>     pub uart_baud: u32,
+>     #[default = LogLevel::Info]
+>     pub max_log_level: LogLevel,
+>     #[default = "/kernel.log"]
+>     pub log_file: &'a str,
+>     #[default = true]
+>     pub allow_hpet: bool,
+>     #[default = None]
+>     pub mac_address: Option<MacAddress>,
 > }
 > ```
 
@@ -49,9 +49,10 @@ Here is the supported properties:
 | `log_file`      | `&str`                                     | Log file path                                            | `"/kernel.log"`  |
 | `allow_hpet`    | `bool`                                     | Allow `HPET` (if present), otherwise always use `PIT`    | `true`           |
 | `log_aml`       | `LogAml` (`off/normal/structured`)         | Log the AML content as ASL code on boot from ACPI tables | `LogAml::Off`    |
+| `mac_address`   | `Option<MacAddress>`                       | MAC address override for the network interface                    | `""`             |
 
 
 If we write these in a command line, it will look like:
 ```
-uart=true uart_baud=115200 max_log_level=info log_file=/kernel.log allow_hpet=true
+uart=true uart_baud=115200 max_log_level=info log_file=/kernel.log allow_hpet=true mac_address=00:11:22:33:44:55
 ```

--- a/kernel/src/devices/net/e1000.rs
+++ b/kernel/src/devices/net/e1000.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     devices::pci::PciDeviceConfig,
     memory_management::virtual_space::VirtualSpace,
-    net::{NetworkError, NetworkPacket},
+    net::{MacAddress, NetworkError, NetworkPacket},
     sync::{once::OnceLock, spin::mutex::Mutex},
     utils::{
         vcell::{RO, RW, WO},
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 
-use super::{MacAddress, NetworkDevice};
+use super::NetworkDevice;
 
 static E1000: OnceLock<Arc<Mutex<E1000>>> = OnceLock::new();
 

--- a/kernel/src/devices/net/e1000.rs
+++ b/kernel/src/devices/net/e1000.rs
@@ -7,6 +7,7 @@ use desc::{Descriptor, DmaRing, ReceiveDescriptor, TransmitDescriptor};
 use tracing::{info, trace, warn};
 
 use crate::{
+    cmdline,
     cpu::{
         self,
         idt::{BasicInterruptHandler, InterruptStackFrame64},
@@ -47,6 +48,11 @@ pub mod flags {
     pub const CTRL_SPEED_100MB: u32 = 1 << 8;
     pub const CTRL_SPEED_1000MB: u32 = 2 << 8;
     pub const CRTL_FORCE_DPLX: u32 = 1 << 12;
+
+    // Receive Address
+    pub const RECV_ADDR_SELECT_DEST: u32 = 0 << 16;
+    pub const RECV_ADDR_SELECT_SRC: u32 = 1 << 16;
+    pub const RECV_ADDR_VALID: u32 = 1 << 31;
 
     // Receive Control
     pub const RCTL_EN: u32 = 1 << 1;
@@ -188,6 +194,8 @@ struct E1000 {
     recv_ring: DmaRing<ReceiveDescriptor, 128>,
     transmit_ring: DmaRing<TransmitDescriptor, 128>,
 
+    current_mac: MacAddress,
+
     received_queue: VecDeque<Vec<u8>>,
     in_middle_of_packet: bool,
 }
@@ -201,14 +209,18 @@ impl E1000 {
         let mut recv_ring = DmaRing::new();
         recv_ring.allocate_all_for_hw();
 
-        Self {
+        let mut s = Self {
             mmio,
             eeprom_size,
             recv_ring,
+            current_mac: MacAddress([0; 6]),
             transmit_ring: DmaRing::new(),
             received_queue: VecDeque::new(),
             in_middle_of_packet: false,
-        }
+        };
+
+        s.current_mac = s.read_eeprom_mac();
+        s
     }
 
     pub fn read_eeprom(&self, offset: u16) -> u16 {
@@ -225,7 +237,7 @@ impl E1000 {
         (self.mmio.eerd.read() >> flags::EERD_DATA_SHIFT) as u16
     }
 
-    pub fn read_mac_address(&self) -> MacAddress {
+    pub fn read_eeprom_mac(&self) -> MacAddress {
         let low = self.read_eeprom(0);
         let mid = self.read_eeprom(1);
         let high = self.read_eeprom(2);
@@ -238,6 +250,21 @@ impl E1000 {
             (high & 0xFF) as u8,
             (high >> 8) as u8,
         ])
+    }
+
+    /// change the MAC address filter to a different one from the EEPROM
+    pub fn set_mac_address(&mut self, mac: MacAddress) {
+        let lower_32 = u32::from_le_bytes(mac.0[0..4].try_into().unwrap());
+        let upper_16 = u16::from_le_bytes(mac.0[4..6].try_into().unwrap()) as u32;
+
+        unsafe {
+            self.mmio.receive_addresses[0].0.write(lower_32);
+            self.mmio.receive_addresses[0]
+                .1
+                .write(upper_16 | flags::RECV_ADDR_VALID | flags::RECV_ADDR_SELECT_DEST);
+        };
+        info!("Set MAC address to {:?}", mac);
+        self.current_mac = mac;
     }
 
     pub fn init_recv(&self) {
@@ -430,7 +457,7 @@ impl E1000 {
 
 impl NetworkDevice for Arc<Mutex<E1000>> {
     fn mac_address(&self) -> MacAddress {
-        self.lock().read_mac_address()
+        self.lock().current_mac
     }
 
     fn send(&self, data: &NetworkPacket) -> Result<(), NetworkError> {
@@ -495,10 +522,13 @@ pub fn try_register(pci_device: &PciDeviceConfig) -> bool {
         cpu::cpu(),
     );
 
-    let e1000 = E1000.get().lock();
+    let mut e1000 = E1000.get().lock();
 
-    info!("MAC address: {:?}", e1000.read_mac_address());
+    info!("MAC address: {:?}", e1000.read_eeprom_mac());
 
+    if let Some(mac_addr) = cmdline::cmdline().mac_address {
+        e1000.set_mac_address(mac_addr);
+    }
     e1000.enable_interrupts();
     e1000.init_recv();
     e1000.init_transmit();

--- a/kernel/src/devices/net/mod.rs
+++ b/kernel/src/devices/net/mod.rs
@@ -1,34 +1,8 @@
 mod e1000;
 
-use core::fmt;
-
-use crate::net::{NetworkError, NetworkPacket};
+use crate::net::{MacAddress, NetworkError, NetworkPacket};
 
 use super::pci::{self, PciDeviceConfig};
-
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
-pub struct MacAddress([u8; 6]);
-
-impl MacAddress {
-    pub fn new(bytes: [u8; 6]) -> Self {
-        MacAddress(bytes)
-    }
-
-    pub fn bytes(&self) -> &[u8; 6] {
-        &self.0
-    }
-}
-
-impl fmt::Debug for MacAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
-            self.0[0], self.0[1], self.0[2], self.0[3], self.0[4], self.0[5]
-        )
-    }
-}
-
 pub trait NetworkDevice {
     fn mac_address(&self) -> MacAddress;
     fn send(&self, data: &NetworkPacket) -> Result<(), NetworkError>;

--- a/kernel/src/net/headers.rs
+++ b/kernel/src/net/headers.rs
@@ -100,8 +100,8 @@ impl NetworkHeader for EthernetHeader {
 
     fn next_header(&self) -> Option<Box<dyn NetworkHeader>> {
         match self.ty {
-            EtherType::Ipv4 => Some(Box::new(Ipv4Header::default())),
-            EtherType::Arp => Some(Box::new(ArpHeader::<Ipv4Address>::default())),
+            EtherType::Ipv4 => Some(Box::<Ipv4Header>::default()),
+            EtherType::Arp => Some(Box::<ArpHeader<Ipv4Address>>::default()),
             _ => None,
         }
     }
@@ -320,8 +320,8 @@ impl NetworkHeader for Ipv4Header {
             return Err(NetworkError::ReachedEndOfStream);
         }
 
-        let checksum = Self::calc_checksum(&buffer[..20]);
         // TODO: looks like some systems send wrong checksum, so hard to make it strict
+        // let checksum = Self::calc_checksum(&buffer[..20]);
         // if checksum != 0 {
         //     return Err(NetworkError::InvalidChecksum);
         // }
@@ -345,7 +345,7 @@ impl NetworkHeader for Ipv4Header {
 
     fn next_header(&self) -> Option<Box<dyn NetworkHeader>> {
         match self.protocol {
-            IpProtocol::Icmp => Some(Box::new(IcmpHeaderAndData::default())),
+            IpProtocol::Icmp => Some(Box::<IcmpHeaderAndData>::default()),
             _ => None,
         }
     }
@@ -432,8 +432,8 @@ impl NetworkHeader for IcmpHeaderAndData {
             return Err(NetworkError::ReachedEndOfStream);
         }
 
-        let checksum = Ipv4Header::calc_checksum(&buffer);
         // TODO: looks like some systems send wrong checksum, so hard to make it strict
+        // let checksum = Ipv4Header::calc_checksum(&buffer);
         // if checksum != 0 {
         //     return Err(NetworkError::InvalidChecksum);
         // }

--- a/kernel/src/net/headers.rs
+++ b/kernel/src/net/headers.rs
@@ -1,0 +1,353 @@
+use core::fmt;
+
+use crate::testing;
+
+use super::{Ipv4Address, MacAddress, NetworkError, NetworkHeader};
+
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum EtherType {
+    #[default]
+    Unknown = 0x0000,
+    Ipv4 = 0x0800,
+    Arp = 0x0806,
+    WakeOnLan = 0x0842,
+    Srp = 0x22EA,
+    Avtp = 0x22F0,
+    IetfThrill = 0x22F3,
+    Rarp = 0x8035,
+    VlanFrame = 0x8100,
+    Slpp = 0x8102,
+    Vlacp = 0x8103,
+    Ipx = 0x8137,
+    QnxQnet = 0x8204,
+    Ipv6 = 0x86DD,
+    EthernetFlowControl = 0x8808,
+    PPPoEDiscovery = 0x8863,
+    PPPoESession = 0x8864,
+    AtaOverEthernet = 0x88A2,
+    Lldp = 0x88CC,
+    Mrp = 0x88E3,
+    Ptp = 0x88F7,
+    Prp = 0x88FB,
+}
+
+impl EtherType {
+    pub fn to_be_bytes(self) -> [u8; 2] {
+        (self as u16).to_be_bytes()
+    }
+
+    fn from_be_bytes(num: [u8; 2]) -> Result<Self, NetworkError> {
+        match u16::from_be_bytes(num) {
+            0x0800 => Ok(EtherType::Ipv4),
+            0x0806 => Ok(EtherType::Arp),
+            0x0842 => Ok(EtherType::WakeOnLan),
+            0x22EA => Ok(EtherType::Srp),
+            0x22F0 => Ok(EtherType::Avtp),
+            0x22F3 => Ok(EtherType::IetfThrill),
+            0x8035 => Ok(EtherType::Rarp),
+            0x8100 => Ok(EtherType::VlanFrame),
+            0x8102 => Ok(EtherType::Slpp),
+            0x8103 => Ok(EtherType::Vlacp),
+            0x8137 => Ok(EtherType::Ipx),
+            0x8204 => Ok(EtherType::QnxQnet),
+            0x86DD => Ok(EtherType::Ipv6),
+            0x8808 => Ok(EtherType::EthernetFlowControl),
+            0x8863 => Ok(EtherType::PPPoEDiscovery),
+            0x8864 => Ok(EtherType::PPPoESession),
+            0x88A2 => Ok(EtherType::AtaOverEthernet),
+            0x88CC => Ok(EtherType::Lldp),
+            0x88E3 => Ok(EtherType::Mrp),
+            0x88F7 => Ok(EtherType::Ptp),
+            0x88FB => Ok(EtherType::Prp),
+            num => Err(NetworkError::UnsupporedEtherType(num)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EthernetHeader {
+    pub dest: MacAddress,
+    pub src: MacAddress,
+    pub ty: EtherType,
+}
+
+impl NetworkHeader for EthernetHeader {
+    fn write_into_buffer(&self, buffer: &mut [u8]) -> Result<(), NetworkError> {
+        buffer[0..6].copy_from_slice(self.dest.bytes());
+        buffer[6..12].copy_from_slice(self.src.bytes());
+        buffer[12..14].copy_from_slice(&self.ty.to_be_bytes());
+        Ok(())
+    }
+
+    fn size(&self) -> usize {
+        14
+    }
+
+    fn read_from_buffer(&mut self, buffer: &[u8]) -> Result<usize, NetworkError> {
+        if buffer.len() < 14 {
+            return Err(NetworkError::ReachedEndOfStream);
+        }
+
+        self.dest = MacAddress(buffer[0..6].try_into().unwrap());
+        self.src = MacAddress(buffer[6..12].try_into().unwrap());
+        self.ty = EtherType::from_be_bytes(buffer[12..14].try_into().unwrap())?;
+
+        Ok(14)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u16)]
+pub enum ArpOperation {
+    #[default]
+    Request = 1,
+    Reply = 2,
+    RequestReverse = 3,
+    ReplyReverse = 4,
+}
+
+impl ArpOperation {
+    pub fn to_be_bytes(self) -> [u8; 2] {
+        (self as u16).to_be_bytes()
+    }
+
+    pub fn from_be_bytes(num: [u8; 2]) -> Result<Self, NetworkError> {
+        match u16::from_be_bytes(num) {
+            1 => Ok(ArpOperation::Request),
+            2 => Ok(ArpOperation::Reply),
+            3 => Ok(ArpOperation::RequestReverse),
+            4 => Ok(ArpOperation::ReplyReverse),
+            num => Err(NetworkError::UnsupporedArpOperation(num)),
+        }
+    }
+}
+
+pub trait ArpProtocol: fmt::Debug {
+    const PROTOCOL: EtherType;
+    const LENGTH: u8;
+
+    fn bytes(&self) -> &[u8];
+    fn new(bytes: &[u8]) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Assume:
+/// - `HardwareType` is always `Ethernet == 1`
+/// - `HardwareLength` is always `6` because `Ethernet`
+pub struct ArpHeader<T: ArpProtocol> {
+    pub operation: ArpOperation,
+    pub sender_hw_addr: MacAddress,
+    pub sender_protocol_addr: T,
+    pub target_hw_addr: MacAddress,
+    pub target_protocol_addr: T,
+}
+
+impl<T: ArpProtocol + 'static> NetworkHeader for ArpHeader<T> {
+    fn write_into_buffer(&self, buffer: &mut [u8]) -> Result<(), NetworkError> {
+        buffer[0..2].copy_from_slice(&1u16.to_be_bytes()); // Ethernet
+        buffer[2..4].copy_from_slice(&T::PROTOCOL.to_be_bytes());
+        buffer[4] = 6; // Ethernet
+        buffer[5] = T::LENGTH;
+        buffer[6..8].copy_from_slice(&self.operation.to_be_bytes());
+        buffer[8..14].copy_from_slice(self.sender_hw_addr.bytes());
+        buffer[14..14 + T::LENGTH as usize].copy_from_slice(self.sender_protocol_addr.bytes());
+
+        let off = 14 + T::LENGTH as usize;
+        buffer[off..off + 6].copy_from_slice(self.target_hw_addr.bytes());
+
+        let off = off + 6;
+        buffer[off..off + T::LENGTH as usize].copy_from_slice(self.target_protocol_addr.bytes());
+
+        Ok(())
+    }
+
+    fn size(&self) -> usize {
+        14 + T::LENGTH as usize * 2 + 6
+    }
+
+    fn read_from_buffer(&mut self, buffer: &[u8]) -> Result<usize, NetworkError> {
+        if buffer.len() < self.size() {
+            return Err(NetworkError::ReachedEndOfStream);
+        }
+
+        self.operation = ArpOperation::from_be_bytes(buffer[6..8].try_into().unwrap())?;
+        self.sender_hw_addr = MacAddress(buffer[8..14].try_into().unwrap());
+        self.sender_protocol_addr =
+            T::new(&buffer[14..14 + T::LENGTH as usize]).expect("Not enough space");
+
+        let off = 14 + T::LENGTH as usize;
+        self.target_hw_addr = MacAddress(buffer[off..off + 6].try_into().unwrap());
+
+        let off = off + 6;
+        self.target_protocol_addr =
+            T::new(&buffer[off..off + T::LENGTH as usize]).expect("Not enough space");
+
+        Ok(off + T::LENGTH as usize)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum IpProtocol {
+    #[default]
+    HopOpt = 0,
+    Icmp = 1,
+    Igmp = 2,
+    Tcp = 6,
+    Udp = 17,
+    Rdp = 27,
+    Encap = 41,
+    Tlsp = 56,
+    Ospf = 89,
+    Sctp = 132,
+}
+impl IpProtocol {
+    fn from_u8(buffer: u8) -> Result<Self, NetworkError> {
+        match buffer {
+            0 => Ok(IpProtocol::HopOpt),
+            1 => Ok(IpProtocol::Icmp),
+            2 => Ok(IpProtocol::Igmp),
+            6 => Ok(IpProtocol::Tcp),
+            17 => Ok(IpProtocol::Udp),
+            27 => Ok(IpProtocol::Rdp),
+            41 => Ok(IpProtocol::Encap),
+            56 => Ok(IpProtocol::Tlsp),
+            89 => Ok(IpProtocol::Ospf),
+            132 => Ok(IpProtocol::Sctp),
+            num => Err(NetworkError::UnsupporedIpProtocol(num)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Ipv4Flags {
+    pub dont_fragment: bool,
+    pub more_fragments: bool,
+}
+
+impl Ipv4Flags {
+    pub fn into_u16(self) -> u16 {
+        ((self.dont_fragment as u16) << 1) | ((self.more_fragments as u16) << 2)
+    }
+
+    fn from_bits(flags: u16) -> Ipv4Flags {
+        Ipv4Flags {
+            dont_fragment: (flags & 0x2) != 0,
+            more_fragments: (flags & 0x4) != 0,
+        }
+    }
+}
+
+/// `Ipv4Header` with some restrictions to thing we care about:
+/// - no `Options`, so its always `Header Length = 5`
+/// - `DSCP` is the default value `0`
+/// - `ECN` is the default value `0`
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Ipv4Header {
+    pub payload_len: u16,
+    pub id: u16,
+    pub flags: Ipv4Flags,
+    pub fragment_offset: u16,
+    pub ttl: u8,
+    pub protocol: IpProtocol,
+    pub source_addr: Ipv4Address,
+    pub dest_addr: Ipv4Address,
+}
+
+impl Ipv4Header {
+    fn calc_checksum(data: &[u8]) -> u16 {
+        let mut sum: u32 = 0;
+        for chunk in data.chunks(2) {
+            let word = u16::from_be_bytes([chunk[0], *chunk.get(1).unwrap_or(&0)]);
+            sum += word as u32;
+        }
+        sum = (sum & 0xFFFF) + (sum >> 16);
+        !(sum as u16)
+    }
+}
+
+impl NetworkHeader for Ipv4Header {
+    fn write_into_buffer(&self, buffer: &mut [u8]) -> Result<(), NetworkError> {
+        assert!(self.payload_len < 0xFFFF - 20, "total len would overflow");
+        assert!(
+            self.fragment_offset <= 0x1FFF,
+            "fragment offset is more than permitted"
+        );
+
+        buffer[0] = 5 | (4 << 4); // IP version 4, 5*32bit data
+        buffer[1] = 0; // DSCP = 0, ECN = 0
+        let total_len = self.payload_len + 20; // header len is 20 for now; no Options
+        buffer[2..4].copy_from_slice(&total_len.to_be_bytes());
+        buffer[4..6].copy_from_slice(&self.id.to_be_bytes());
+        let flags_and_fragment_off =
+            (self.fragment_offset & 0x1FFF) | (self.flags.into_u16() << 13);
+        buffer[6..8].copy_from_slice(&flags_and_fragment_off.to_be_bytes());
+        buffer[8] = self.ttl;
+        buffer[9] = self.protocol as u8;
+        buffer[10] = 0; // fill checksum with 0 during computation, refill it later
+        buffer[11] = 0;
+        buffer[12..16].copy_from_slice(self.source_addr.bytes());
+        buffer[16..20].copy_from_slice(self.dest_addr.bytes());
+
+        // put checksum
+        let checksum = Self::calc_checksum(&buffer[..20]);
+        buffer[10..12].copy_from_slice(&checksum.to_be_bytes());
+
+        Ok(())
+    }
+
+    fn size(&self) -> usize {
+        // TODO: implement `Options`
+        20
+    }
+
+    fn read_from_buffer(&mut self, buffer: &[u8]) -> Result<usize, NetworkError> {
+        if buffer.len() < self.size() {
+            return Err(NetworkError::ReachedEndOfStream);
+        }
+
+        let checksum = Self::calc_checksum(&buffer[..20]);
+        // TODO: looks like some systems send wrong checksum, so hard to make it strict
+        // if checksum != 0 {
+        //     return Err(NetworkError::InvalidChecksum);
+        // }
+
+        let total_len = u16::from_be_bytes(buffer[2..4].try_into().unwrap());
+        if total_len < 20 {
+            return Err(NetworkError::InvalidHeader);
+        }
+        self.payload_len = total_len - 20;
+        self.id = u16::from_be_bytes(buffer[4..6].try_into().unwrap());
+        let flags_and_fragment_off = u16::from_be_bytes(buffer[6..8].try_into().unwrap());
+        self.fragment_offset = flags_and_fragment_off & 0x1FFF;
+        self.flags = Ipv4Flags::from_bits(flags_and_fragment_off >> 13);
+        self.ttl = buffer[8];
+        self.protocol = IpProtocol::from_u8(buffer[9])?;
+        self.source_addr = Ipv4Address(buffer[12..16].try_into().unwrap());
+        self.dest_addr = Ipv4Address(buffer[16..20].try_into().unwrap());
+
+        Ok(20)
+    }
+}
+
+#[macro_rules_attribute::apply(testing::test)]
+fn test_parse_ethernet_header() {
+    let mut header = EthernetHeader::default();
+    let buffer = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, // dest
+        0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, // src
+        0x08, 0x00, // type
+    ];
+
+    assert_eq!(header.read_from_buffer(&buffer), Ok(14));
+    assert_eq!(
+        header.dest,
+        MacAddress([0x00, 0x01, 0x02, 0x03, 0x04, 0x05])
+    );
+    assert_eq!(header.src, MacAddress([0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]));
+    assert_eq!(header.ty, EtherType::Ipv4);
+}

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -111,7 +111,7 @@ impl NetworkPacket {
         self.clear();
 
         let mut ethernet = EthernetHeader::create();
-        let mut off = ethernet.read_from_buffer(&buffer)?;
+        let mut off = ethernet.read_from_buffer(buffer)?;
 
         let mut next_header = ethernet.next_header();
         self.push(ethernet);
@@ -233,6 +233,7 @@ impl ArpProtocol for Ipv4Address {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum NetworkError {
     ReachedEndOfStream,
     NotEnoughSpace,

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -1,4 +1,7 @@
+mod headers;
 pub mod socket;
+
+pub use headers::*;
 
 use core::{any::Any, fmt};
 
@@ -132,98 +135,6 @@ impl fmt::Debug for MacAddress {
     }
 }
 
-#[repr(u16)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum EtherType {
-    #[default]
-    Unknown = 0x0000,
-    Ipv4 = 0x0800,
-    Arp = 0x0806,
-    WakeOnLan = 0x0842,
-    Srp = 0x22EA,
-    Avtp = 0x22F0,
-    IetfThrill = 0x22F3,
-    Rarp = 0x8035,
-    VlanFrame = 0x8100,
-    Slpp = 0x8102,
-    Vlacp = 0x8103,
-    Ipx = 0x8137,
-    QnxQnet = 0x8204,
-    Ipv6 = 0x86DD,
-    EthernetFlowControl = 0x8808,
-    PPPoEDiscovery = 0x8863,
-    PPPoESession = 0x8864,
-    AtaOverEthernet = 0x88A2,
-    Lldp = 0x88CC,
-    Mrp = 0x88E3,
-    Ptp = 0x88F7,
-    Prp = 0x88FB,
-}
-
-impl EtherType {
-    pub fn to_be_bytes(self) -> [u8; 2] {
-        (self as u16).to_be_bytes()
-    }
-
-    fn from_be_bytes(num: [u8; 2]) -> Result<Self, NetworkError> {
-        match u16::from_be_bytes(num) {
-            0x0800 => Ok(EtherType::Ipv4),
-            0x0806 => Ok(EtherType::Arp),
-            0x0842 => Ok(EtherType::WakeOnLan),
-            0x22EA => Ok(EtherType::Srp),
-            0x22F0 => Ok(EtherType::Avtp),
-            0x22F3 => Ok(EtherType::IetfThrill),
-            0x8035 => Ok(EtherType::Rarp),
-            0x8100 => Ok(EtherType::VlanFrame),
-            0x8102 => Ok(EtherType::Slpp),
-            0x8103 => Ok(EtherType::Vlacp),
-            0x8137 => Ok(EtherType::Ipx),
-            0x8204 => Ok(EtherType::QnxQnet),
-            0x86DD => Ok(EtherType::Ipv6),
-            0x8808 => Ok(EtherType::EthernetFlowControl),
-            0x8863 => Ok(EtherType::PPPoEDiscovery),
-            0x8864 => Ok(EtherType::PPPoESession),
-            0x88A2 => Ok(EtherType::AtaOverEthernet),
-            0x88CC => Ok(EtherType::Lldp),
-            0x88E3 => Ok(EtherType::Mrp),
-            0x88F7 => Ok(EtherType::Ptp),
-            0x88FB => Ok(EtherType::Prp),
-            num => Err(NetworkError::UnsupporedEtherType(num)),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct EthernetHeader {
-    pub dest: MacAddress,
-    pub src: MacAddress,
-    pub ty: EtherType,
-}
-
-impl NetworkHeader for EthernetHeader {
-    fn write_into_buffer(&self, buffer: &mut [u8]) -> Result<(), NetworkError> {
-        buffer[0..6].copy_from_slice(self.dest.bytes());
-        buffer[6..12].copy_from_slice(self.src.bytes());
-        buffer[12..14].copy_from_slice(&self.ty.to_be_bytes());
-        Ok(())
-    }
-
-    fn size(&self) -> usize {
-        14
-    }
-
-    fn read_from_buffer(&mut self, buffer: &[u8]) -> Result<usize, NetworkError> {
-        if buffer.len() < 14 {
-            return Err(NetworkError::ReachedEndOfStream);
-        }
-
-        self.dest = MacAddress(buffer[0..6].try_into().unwrap());
-        self.src = MacAddress(buffer[6..12].try_into().unwrap());
-        self.ty = EtherType::from_be_bytes(buffer[12..14].try_into().unwrap())?;
-
-        Ok(14)
-    }
-}
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub struct Ipv4Address(pub [u8; 4]);
 
@@ -262,122 +173,16 @@ impl ArpProtocol for Ipv4Address {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(u16)]
-pub enum ArpOperation {
-    #[default]
-    Request = 1,
-    Reply = 2,
-    RequestReverse = 3,
-    ReplyReverse = 4,
-}
-
-impl ArpOperation {
-    pub fn to_be_bytes(self) -> [u8; 2] {
-        (self as u16).to_be_bytes()
-    }
-
-    pub fn from_be_bytes(num: [u8; 2]) -> Result<Self, NetworkError> {
-        match u16::from_be_bytes(num) {
-            1 => Ok(ArpOperation::Request),
-            2 => Ok(ArpOperation::Reply),
-            3 => Ok(ArpOperation::RequestReverse),
-            4 => Ok(ArpOperation::ReplyReverse),
-            num => Err(NetworkError::UnsupporedEtherType(num)),
-        }
-    }
-}
-
-pub trait ArpProtocol: fmt::Debug {
-    const PROTOCOL: EtherType;
-    const LENGTH: u8;
-
-    fn bytes(&self) -> &[u8];
-    fn new(bytes: &[u8]) -> Option<Self>
-    where
-        Self: Sized;
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-/// Assume:
-/// - `HardwareType` is always `Ethernet == 1`
-/// - `HardwareLength` is always `6` because `Ethernet`
-pub struct ArpHeader<T: ArpProtocol> {
-    pub operation: ArpOperation,
-    pub sender_hw_addr: MacAddress,
-    pub sender_protocol_addr: T,
-    pub target_hw_addr: MacAddress,
-    pub target_protocol_addr: T,
-}
-
-impl<T: ArpProtocol + 'static> NetworkHeader for ArpHeader<T> {
-    fn write_into_buffer(&self, buffer: &mut [u8]) -> Result<(), NetworkError> {
-        buffer[0..2].copy_from_slice(&1u16.to_be_bytes()); // Ethernet
-        buffer[2..4].copy_from_slice(&T::PROTOCOL.to_be_bytes());
-        buffer[4] = 6; // Ethernet
-        buffer[5] = T::LENGTH;
-        buffer[6..8].copy_from_slice(&self.operation.to_be_bytes());
-        buffer[8..14].copy_from_slice(self.sender_hw_addr.bytes());
-        buffer[14..14 + T::LENGTH as usize].copy_from_slice(self.sender_protocol_addr.bytes());
-
-        let off = 14 + T::LENGTH as usize;
-        buffer[off..off + 6].copy_from_slice(self.target_hw_addr.bytes());
-
-        let off = off + 6;
-        buffer[off..off + T::LENGTH as usize].copy_from_slice(self.target_protocol_addr.bytes());
-
-        Ok(())
-    }
-
-    fn size(&self) -> usize {
-        14 + T::LENGTH as usize * 2 + 6
-    }
-
-    fn read_from_buffer(&mut self, buffer: &[u8]) -> Result<usize, NetworkError> {
-        if buffer.len() < self.size() {
-            return Err(NetworkError::ReachedEndOfStream);
-        }
-
-        self.operation = ArpOperation::from_be_bytes(buffer[6..8].try_into().unwrap())?;
-        self.sender_hw_addr = MacAddress(buffer[8..14].try_into().unwrap());
-        self.sender_protocol_addr =
-            T::new(&buffer[14..14 + T::LENGTH as usize]).expect("Not enough space");
-
-        let off = 14 + T::LENGTH as usize;
-        self.target_hw_addr = MacAddress(buffer[off..off + 6].try_into().unwrap());
-
-        let off = off + 6;
-        self.target_protocol_addr =
-            T::new(&buffer[off..off + T::LENGTH as usize]).expect("Not enough space");
-
-        Ok(off + T::LENGTH as usize)
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkError {
     ReachedEndOfStream,
     NotEnoughSpace,
     UnsupporedEtherType(u16),
     PacketTooLarge(usize),
-}
-
-#[macro_rules_attribute::apply(testing::test)]
-fn test_parse_ethernet_header() {
-    let mut header = EthernetHeader::default();
-    let buffer = [
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, // dest
-        0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, // src
-        0x08, 0x00, // type
-    ];
-
-    assert_eq!(header.read_from_buffer(&buffer), Ok(14));
-    assert_eq!(
-        header.dest,
-        MacAddress([0x00, 0x01, 0x02, 0x03, 0x04, 0x05])
-    );
-    assert_eq!(header.src, MacAddress([0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]));
-    assert_eq!(header.ty, EtherType::Ipv4);
+    InvalidHeader,
+    InvalidChecksum,
+    UnsupporedIpProtocol(u8),
+    UnsupporedArpOperation(u16),
 }
 
 #[macro_rules_attribute::apply(testing::test)]

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -1,3 +1,5 @@
+use crate::cpu;
+
 use super::{MacAddress, NetworkError, NetworkPacket};
 
 pub struct EthernetSocket {
@@ -18,6 +20,13 @@ impl EthernetSocket {
         crate::devices::net::get_device()
             .unwrap()
             .receive_into(packet)
+    }
+
+    pub fn wait_and_receive(&self, packet: &mut NetworkPacket) -> Result<(), NetworkError> {
+        while !self.receive(packet)? {
+            unsafe { cpu::halt() };
+        }
+        Ok(())
     }
 
     pub fn mac_address(&self) -> MacAddress {

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -1,4 +1,4 @@
-use super::{NetworkError, NetworkPacket};
+use super::{MacAddress, NetworkError, NetworkPacket};
 
 pub struct EthernetSocket {
     _private: (),
@@ -18,5 +18,9 @@ impl EthernetSocket {
         crate::devices::net::get_device()
             .unwrap()
             .receive_into(packet)
+    }
+
+    pub fn mac_address(&self) -> MacAddress {
+        crate::devices::net::get_device().unwrap().mac_address()
     }
 }


### PR DESCRIPTION
## Summary

<!-- Please provide a brief description of the changes made in this PR -->

Create abstractions to handle ICMP, and IPV4 packets on the network stack


### Related issue

<!-- Mention any relevant issues like #123 -->
Work toward #75 


## Changes

- Add `ARP` packet handling
- Add `Ipv4Address` struct
- Add `mac_address` cmdline parameter that can be used to override the default mac address.


## Checklist

- [ ] The changes are tested and works as expected (mention if not)
- [ ] Tests if applicable (new features, regression tests, etc...)
- [ ] Documentation
- [ ] Needed README changes
