### PR TITLE
Profiling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-xtask = "run --package xtask --"
+xtask = "run --package xtask --release --"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,14 +4,14 @@
         {
             "name": "Debug QEMU",
             "type": "lldb",
-            "request": "custom",
+            "request": "launch",
             "targetCreateCommands": [
                 "target create ${workspaceFolder}/target/x86-64-os/debug/kernel",
                 // ignore first interrupt on startup because its annoying, just jump directly into the kernel
                 "process handle -p true -s false SIGTRAP",
             ],
             "processCreateCommands": ["gdb-remote localhost:1234"],
-            "preLaunchTask": "build and run",
+            "preLaunchTask": "build and run"
         }
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -313,19 +313,6 @@ dependencies = [
 
 [[package]]
 name = "framehop"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1940574e932d1ed75aab25420312c0019d8dd91c6125bd51420272cd072008e"
-dependencies = [
- "arrayvec",
- "cfg-if",
- "fallible-iterator",
- "gimli 0.29.0",
- "thiserror-no-std",
-]
-
-[[package]]
-name = "framehop"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0586ca77af938ae3d66a103d3082ac997b432e82e65d644be6ad2fa340f582d"
@@ -333,7 +320,7 @@ dependencies = [
  "arrayvec",
  "cfg-if",
  "fallible-iterator",
- "gimli 0.32.0",
+ "gimli",
  "macho-unwind-info",
  "pe-unwind-info",
 ]
@@ -351,12 +338,6 @@ dependencies = [
  "rustversion",
  "windows",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "gimli"
@@ -464,7 +445,7 @@ dependencies = [
  "byteorder",
  "embedded-graphics",
  "emerald_kernel_user_link",
- "framehop 0.11.2",
+ "framehop",
  "increasing_heap_allocator",
  "macro_rules_attribute",
  "tracing 0.2.0",
@@ -812,7 +793,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -865,17 +846,6 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
@@ -911,7 +881,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -922,27 +892,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "thiserror-impl-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "thiserror-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
-dependencies = [
- "thiserror-impl-no-std",
+ "syn",
 ]
 
 [[package]]
@@ -1029,7 +979,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d80f6c2bfede213d9a90b4a14f3eb99b84e33c52df6c1a15de0a100f5a88751"
 dependencies = [
- "gimli 0.32.0",
+ "gimli",
 ]
 
 [[package]]
@@ -1060,7 +1010,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1082,7 +1032,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1172,7 +1122,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1183,7 +1133,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1310,7 +1260,7 @@ dependencies = [
  "argh",
  "cargo_metadata",
  "elf",
- "framehop 0.14.0",
+ "framehop",
  "glob",
  "qapi",
  "rustc-demangle",
@@ -1333,7 +1283,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "blinkcast"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,7 +156,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -218,6 +230,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "elf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55dd888a213fc57e957abf2aa305ee3e8a28dbe05687a251f33b637cd46b0070"
 
 [[package]]
 name = "embedded-graphics"
@@ -307,6 +325,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "framehop"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0586ca77af938ae3d66a103d3082ac997b432e82e65d644be6ad2fa340f582d"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "fallible-iterator",
+ "gimli 0.32.0",
+ "macho-unwind-info",
+ "pe-unwind-info",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +363,10 @@ name = "gimli"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
+dependencies = [
+ "fallible-iterator",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -428,7 +464,7 @@ dependencies = [
  "byteorder",
  "embedded-graphics",
  "emerald_kernel_user_link",
- "framehop",
+ "framehop 0.11.2",
  "increasing_heap_allocator",
  "macro_rules_attribute",
  "tracing 0.2.0",
@@ -465,6 +501,17 @@ dependencies = [
  "scoped-tls",
  "tracing 0.1.41",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "macho-unwind-info"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4bdc8b0ce69932332cf76d24af69c3a155242af95c226b2ab6c2e371ed1149"
+dependencies = [
+ "thiserror 2.0.12",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -551,6 +598,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pe-unwind-info"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500fa4cdeacd98997c5865e3d0d1cb8fe7e9d7d75ecc775e07989a433a9a9a59"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "thiserror 2.0.12",
+ "zerocopy",
+ "zerocopy-derive",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +623,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "qapi"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b047adab56acc4948d4b9b58693c1f33fd13efef2d6bb5f0f66a47436ceada8"
+dependencies = [
+ "log",
+ "qapi-qga",
+ "qapi-qmp",
+ "qapi-spec",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "qapi-codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb959fed63a69baa2e3ae57224d885e686bc3f56c9bb3b03406969980ea57a44"
+dependencies = [
+ "qapi-parser",
+]
+
+[[package]]
+name = "qapi-parser"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b37f643cfdf67a409a9323334138a11636a5db5d56cedcc780d7a82a7fb7659"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "qapi-qga"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2945a1829999b7e600b98c8326615ece10df20bc9e9ab12ec057a6aa29b7317d"
+dependencies = [
+ "qapi-codegen",
+ "qapi-spec",
+ "serde",
+]
+
+[[package]]
+name = "qapi-qmp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45303cac879d89361cad0287ae15f9ae1e7799b904b474152414aeece39b9875"
+dependencies = [
+ "qapi-codegen",
+ "qapi-spec",
+ "serde",
+]
+
+[[package]]
+name = "qapi-spec"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e6bdbbe5d13015b21a49a778a29ae3cee9c450c3154e1648aed670d57fe5ba"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -623,6 +749,12 @@ name = "rust-fuzzy-search"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a157657054ffe556d8858504af8a672a054a6e0bd9e8ee531059100c0fa11bb2"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-std-workspace-alloc"
@@ -726,6 +858,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,7 +891,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -761,6 +908,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1151,7 +1309,31 @@ dependencies = [
  "anyhow",
  "argh",
  "cargo_metadata",
+ "elf",
+ "framehop 0.14.0",
  "glob",
+ "qapi",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,14 @@ dependencies = [
  "glob",
  "qapi",
  "rustc-demangle",
+ "xxhash-rust",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ jpeg-decoder = { git = "https://github.com/Amjad50/jpeg-decoder", branch = "mast
 
 [profile.test]
 opt-level = 2
+
+[profile.profile]
+inherits = "dev"
+opt-level = 2
+debug = true
+

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,6 +1,8 @@
 # Summary
 
 - [Introduction](./index.md)
+- [xtask](./xtask/index.md)
+    - [Profiler](./xtask/profiler.md)
 - [Kernel](./kernel/index.md)
     - [Boot](./kernel/boot/index.md)
         - [Command Line](./kernel/boot/cmdline.md)

--- a/book/src/xtask/index.md
+++ b/book/src/xtask/index.md
@@ -1,0 +1,24 @@
+# xtask
+
+`xtask` is the tool that helps us build, test and run the kernel and userspace programs.
+Its a custom wrapper around `cargo` and various other tools to make developing `Emerald` easier.
+
+```txt
+Usage: xtask [--release] [--profile] <command> [<args>]
+
+XTask - a task runner
+
+Options:
+  --release         build in release mode
+  --profile         use profile mode (and run qmp socket when running qemu)
+  --help, help      display usage information
+
+Commands:
+  run               Run the kernel
+  test              Test the kernel
+  build-iso         Build the kernel ISO
+  kernel            Run rust commands on the kernel
+  userspace         Run rust commands on the userspace programs
+  toolchain         Build the toolchain distribution
+  profiler          Profile the kernel using QMP
+```

--- a/book/src/xtask/profiler.md
+++ b/book/src/xtask/profiler.md
@@ -1,0 +1,34 @@
+# Profiler
+
+Profiling the kernel is one of the most important tasks we have in order to improve its performance.
+
+I was thinking first, about making a trace of the kernel state interrupts, but that would have some issues:
+- Hard to implement and export the data (maybe export to disk?).
+- The analysis would also be part of the trace, which would make it more annoying to separate the real data from trace
+  processing calls.
+
+## Qemu (QMP)
+Qemu has an interface to communicate and analyze the guest system from outside, called QMP (Qemu Machine Protocol).
+It allows us to send commands to the Qemu instance and get the results back.
+
+Such as:
+- `query-cpus`: Get the current state of the CPUs.
+- `stop`: Pause the Qemu instance.
+- `cont`: Continue the Qemu instance.
+- `human-monitor`: Send gdb like commands to the Qemu instance.
+    - such as `info registers` to get the current state of the registers.
+    - `x/1x ...` read memory at the given address.
+
+Using all of that we have built a profiler in `xtask` that does the following:
+- Read the dwarf information and the symbols information form the kernel binary, and store it.
+- Connect to the Qemu instance using QMP.
+- On every interval (configured)
+    - Stop the Qemu instance. (to keep the memory state consistent, even though it can sample without stopping).
+    - Get `RIP`, `RSP`, `RBP` registers of the CPU (currently, we have 1 CPU only).
+    - Use [`framehop`](https://github.com/mstange/framehop) to trace the stack using these variables as well as the gdb command to
+      read any memory address.
+    - Use the symbols to resolve the function names for each stack frame.
+    - Group them together in 1 collapsed stack trace.
+- Collect all collapsed stack traces and their counts into one file.
+
+The collected collapsed stacks are then used to generate flamegraph ([https://www.speedscope.app](https://www.speedscope.app) is a good tool for viewing these files).

--- a/book/src/xtask/profiler.md
+++ b/book/src/xtask/profiler.md
@@ -12,7 +12,6 @@ Qemu has an interface to communicate and analyze the guest system from outside, 
 It allows us to send commands to the Qemu instance and get the results back.
 
 Such as:
-- `query-cpus`: Get the current state of the CPUs.
 - `stop`: Pause the Qemu instance.
 - `cont`: Continue the Qemu instance.
 - `human-monitor`: Send gdb like commands to the Qemu instance.
@@ -35,6 +34,18 @@ Using all of that we have built a profiler in `xtask` that does the following:
 - Collect all collapsed stack traces and their counts into one file.
 
 The collected collapsed stacks are then used to generate flamegraph ([https://www.speedscope.app](https://www.speedscope.app) is a good tool for viewing these files).
+
+## How to use
+
+In order to profile the OS, the easiest way is to use `xtask` with profiling commands:
+
+```sh
+# Run the kernel in profiling mode
+cargo xtask --profile run
+
+# In another terminal, run the profiler
+cargo xtask profiler -o stack.folded
+```
 
 ## Features
 
@@ -92,6 +103,8 @@ cargo xtask --profile profiler --verbose --show-addresses --one-shot
 - `--show-addresses`: Show raw addresses alongside symbols (only in `--one-shot` mode)
 - `--one-shot`: Capture single stack trace and exit
 - `--profile <mode>`: Override profile mode (debug/release/profile)
+- `--kernel-only`: Only profile kernel execution, skip userspace
+- `--user-only`: Only profile userspace execution, skip kernel
 
 ## Implementation Details
 

--- a/book/src/xtask/profiler.md
+++ b/book/src/xtask/profiler.md
@@ -21,14 +21,88 @@ Such as:
 
 Using all of that we have built a profiler in `xtask` that does the following:
 - Read the dwarf information and the symbols information form the kernel binary, and store it.
+- Load userspace program symbols from ELF files in the userspace output directory, using `.text` section hashes for identification.
 - Connect to the Qemu instance using QMP.
 - On every interval (configured)
     - Stop the Qemu instance. (to keep the memory state consistent, even though it can sample without stopping).
     - Get `RIP`, `RSP`, `RBP` registers of the CPU (currently, we have 1 CPU only).
+    - Detect whether execution is in kernel or userspace based on the instruction pointer address.
+    - For userspace execution: read process metadata, dynamically load userspace module symbols and unwinding info.
     - Use [`framehop`](https://github.com/mstange/framehop) to trace the stack using these variables as well as the gdb command to
       read any memory address.
-    - Use the symbols to resolve the function names for each stack frame.
-    - Group them together in 1 collapsed stack trace.
+    - Use the symbols to resolve the function names for each stack frame (both kernel and userspace).
+    - Group them together in 1 collapsed stack trace with process identification.
 - Collect all collapsed stack traces and their counts into one file.
 
 The collected collapsed stacks are then used to generate flamegraph ([https://www.speedscope.app](https://www.speedscope.app) is a good tool for viewing these files).
+
+## Features
+
+### Kernel and Userspace Profiling
+The profiler supports both kernel and userspace execution profiling:
+- **Kernel profiling**: Traces execution within the kernel using kernel symbols and DWARF debug information
+- **Userspace profiling**: Dynamically detects userspace processes and loads their symbols for accurate stack unwinding
+- **Process identification**: Tracks individual processes by PID and program name in stack traces
+
+### Symbol Resolution
+- Loads ELF debug information from kernel binary at startup
+- Caches userspace program symbols using `.text` section hashes for efficient lookup
+- Falls back to raw addresses when symbols are unavailable (or couldn't load the process metadata)
+
+### Stack Unwinding
+- Uses the [`framehop`](https://github.com/mstange/framehop) library
+- Supports x86_64 DWARF-based unwinding using `.eh_frame` sections
+- Handles both kernel and userspace stack frames in mixed traces
+- Dynamically switches between kernel and userspace unwinding contexts
+
+### Sampling Modes
+- **One-shot mode**: Captures a single stack trace for immediate analysis
+- **Continuous sampling**: Collects samples over a specified duration with configurable intervals
+- **Configurable timing**: Adjustable sampling interval (default 10ms) and duration (default 5s)
+
+### Output Formats
+- **Console output**: Real-time stack traces with statistics
+- **Folded stack format**: Compatible with flamegraph tools for visualization
+- **Process tracking**: Identifies samples by kernel vs userspace and specific process names
+
+## Usage
+
+The profiler is run through the `xtask` command:
+
+```bash
+# Basic profiling for 5 seconds
+cargo xtask --profile profiler
+
+# One-shot stack trace
+cargo xtask --profile profiler --one-shot
+
+# Extended sampling with custom parameters
+cargo xtask --profile profiler --duration 30 --interval 5 --output profile.folded
+
+# Verbose output with addresses
+cargo xtask --profile profiler --verbose --show-addresses --one-shot
+```
+
+### Command Line Options
+- `--qmp-socket <path>`: QMP socket path (default: ./qmp-socket)
+- `--interval <ms>`: Sampling interval in milliseconds (default: 10)
+- `--duration <sec>`: Sampling duration in seconds (default: 5)
+- `--output <file>`: Output file for folded stack samples
+- `--verbose`: Enable detailed output including timing information
+- `--show-addresses`: Show raw addresses alongside symbols (only in `--one-shot` mode)
+- `--one-shot`: Capture single stack trace and exit
+- `--profile <mode>`: Override profile mode (debug/release/profile)
+
+## Implementation Details
+
+### Process Detection
+The profiler distinguishes between kernel and userspace execution by examining the instruction pointer:
+- Addresses ≥ `0xFFFFFFFF80000000` are considered kernel space
+- Lower addresses trigger userspace process metadata collection
+
+### Dynamic Symbol Loading
+For userspace processes, the profiler:
+1. Reads process metadata from a fixed kernel memory location
+2. Extracts `.text` and `.eh_frame` sections from process memory
+3. Computes a hash of the `.text` section for symbol cache lookup
+4. Dynamically loads matching symbols and unwinding information

--- a/extern/toolchain/config.toml
+++ b/extern/toolchain/config.toml
@@ -3,7 +3,7 @@
 # See `src/bootstrap/defaults` for more information.
 # Note that this has no default value (x.py uses the defaults in `config.example.toml`).
 # profile = 'dist'
-change-id = 124501
+change-id = 143926
 
 [llvm]
 download-ci-llvm = "if-unchanged"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -12,7 +12,7 @@ embedded-graphics = { version = "0.8.1", default-features = false }
 byteorder = { version = "1.5", default-features = false }
 blinkcast = "0.2"
 unwinding = { version = "0.2", features = ['unwinder', 'panic', 'personality', 'fde-static'], default-features = false }
-framehop =  { version = "0.11.2", default-features = false }
+framehop =  { version = "0.14", default-features = false }
 tracing = { version = "0.2", git = "https://github.com/tokio-rs/tracing", branch = "v0.2.x", default-features = false }
 tracing-core = { version = "0.2", git = "https://github.com/tokio-rs/tracing", branch = "v0.2.x", default-features = false }
 macro_rules_attribute = "0.2.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,3 +10,7 @@ anyhow = "1.0.81"
 argh = "0.1.12"
 cargo_metadata = "0.18.1"
 glob = "0.3.1"
+qapi = { version = "0.15", features = ["qapi-qmp", "qapi-qga"] }
+framehop = "0.14"
+elf = "0.8"
+rustc-demangle = "0.1"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "MIT"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,3 +14,5 @@ qapi = { version = "0.15", features = ["qapi-qmp", "qapi-qga"] }
 framehop = "0.14"
 elf = "0.8"
 rustc-demangle = "0.1"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
+

--- a/xtask/src/args.rs
+++ b/xtask/src/args.rs
@@ -171,4 +171,16 @@ pub struct Profiler {
         description = "by default we will check for `--profile` runs, but if you want to profile `release` or `debug`, put it here"
     )]
     pub profile_mode: Option<String>,
+
+    #[argh(switch, long = "kernel-only", short = 'k')]
+    #[argh(
+        description = "only profile the kernel, not userspace programs (default: false, profiles both kernel and userspace)"
+    )]
+    pub kernel_only: bool,
+
+    #[argh(switch, long = "user-only", short = 'u')]
+    #[argh(
+        description = "only profile userspace programs, not the kernel (default: false, profiles both kernel and userspace)"
+    )]
+    pub user_only: bool,
 }

--- a/xtask/src/args.rs
+++ b/xtask/src/args.rs
@@ -166,10 +166,6 @@ pub struct Profiler {
     #[argh(description = "collect a single stack trace and exit")]
     pub one_shot: bool,
 
-    #[argh(option, long = "user-program", short = 'u')]
-    #[argh(description = "userspace program that you want to profile (not accurate for now...)")]
-    pub user_program: Option<String>,
-
     #[argh(option, long = "profile", short = 'p')]
     #[argh(
         description = "by default we will check for `--profile` runs, but if you want to profile `release` or `debug`, put it here"

--- a/xtask/src/args.rs
+++ b/xtask/src/args.rs
@@ -161,4 +161,8 @@ pub struct Profiler {
     #[argh(switch, long = "one-shot")]
     #[argh(description = "collect a single stack trace and exit")]
     pub one_shot: bool,
+
+    #[argh(option, long = "user-program", short = 'u')]
+    #[argh(description = "userspace program that you want to profile (not accurate for now...)")]
+    pub user_program: Option<String>,
 }

--- a/xtask/src/args.rs
+++ b/xtask/src/args.rs
@@ -20,6 +20,7 @@ pub enum Command {
     Kernel(Kernel),
     Userspace(Userspace),
     Toolchain(Toolchain),
+    Profiler(Profiler),
 }
 
 #[derive(FromArgs, Debug)]
@@ -127,4 +128,37 @@ pub struct Toolchain {
     #[argh(option, long = "out", short = 'o')]
     #[argh(description = "output folder to copy the dist files into")]
     pub out: Option<String>,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "profiler")]
+#[argh(description = "Profile the kernel using QMP")]
+pub struct Profiler {
+    #[argh(option, long = "qmp-socket")]
+    #[argh(description = "QMP socket to connect to")]
+    pub qmp_socket: String,
+
+    #[argh(option, long = "interval", default = "10")]
+    #[argh(description = "sampling interval in milliseconds  (default: 10)")]
+    pub interval_ms: u64,
+
+    #[argh(option, long = "duration", default = "5")]
+    #[argh(description = "sampling duration in seconds (default: 5)")]
+    pub duration_sec: u64,
+
+    #[argh(option, long = "output", short = 'o')]
+    #[argh(description = "output file for folded stack samples (for flamegraph generation)")]
+    pub output: Option<String>,
+
+    #[argh(switch, long = "verbose", short = 'v')]
+    #[argh(description = "enable verbose output")]
+    pub verbose: bool,
+
+    #[argh(switch, long = "show-addresses")]
+    #[argh(description = "show raw addresses alongside symbols")]
+    pub show_addresses: bool,
+
+    #[argh(switch, long = "one-shot")]
+    #[argh(description = "collect a single stack trace and exit")]
+    pub one_shot: bool,
 }

--- a/xtask/src/args.rs
+++ b/xtask/src/args.rs
@@ -9,6 +9,10 @@ pub struct Args {
     #[argh(switch, long = "release")]
     #[argh(description = "build in release mode")]
     pub release: bool,
+
+    #[argh(switch, long = "profile")]
+    #[argh(description = "use profile mode (and run qmp socket when running qemu)")]
+    pub profile: bool,
 }
 
 #[derive(FromArgs, Debug)]
@@ -135,8 +139,8 @@ pub struct Toolchain {
 #[argh(description = "Profile the kernel using QMP")]
 pub struct Profiler {
     #[argh(option, long = "qmp-socket")]
-    #[argh(description = "QMP socket to connect to")]
-    pub qmp_socket: String,
+    #[argh(description = "QMP socket to connect to (default ./qmp-socket)")]
+    pub qmp_socket: Option<String>,
 
     #[argh(option, long = "interval", default = "10")]
     #[argh(description = "sampling interval in milliseconds  (default: 10)")]
@@ -165,4 +169,10 @@ pub struct Profiler {
     #[argh(option, long = "user-program", short = 'u')]
     #[argh(description = "userspace program that you want to profile (not accurate for now...)")]
     pub user_program: Option<String>,
+
+    #[argh(option, long = "profile", short = 'p')]
+    #[argh(
+        description = "by default we will check for `--profile` runs, but if you want to profile `release` or `debug`, put it here"
+    )]
+    pub profile_mode: Option<String>,
 }

--- a/xtask/src/kernel/build.rs
+++ b/xtask/src/kernel/build.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use crate::{
+    GlobalMeta,
     args::Build,
     utils::{has_changed, run_cmd},
-    GlobalMeta,
 };
 
 pub fn build_kernel(meta: &GlobalMeta, build: Build) -> anyhow::Result<PathBuf> {

--- a/xtask/src/kernel/check.rs
+++ b/xtask/src/kernel/check.rs
@@ -1,7 +1,7 @@
 use crate::{
+    GlobalMeta,
     args::{Check, Clippy, Fmt},
     utils::run_cmd,
-    GlobalMeta,
 };
 
 fn kernel_run_cargo(

--- a/xtask/src/kernel/iso.rs
+++ b/xtask/src/kernel/iso.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::{
-    utils::{copy_files, has_changed, run_cmd},
     GlobalMeta,
+    utils::{copy_files, has_changed, run_cmd},
 };
 
 use super::{build::build_kernel, test::build_test_kernel};

--- a/xtask/src/kernel/run.rs
+++ b/xtask/src/kernel/run.rs
@@ -91,7 +91,7 @@ impl RunConfig {
 
         cmd.args(extra_args);
 
-        println!("[+] Running the kernel: {:?}", cmd);
+        println!("[+] Running the kernel: {cmd:?}");
 
         cmd.status()
             .map(|status| status.code().unwrap_or(1))

--- a/xtask/src/kernel/run.rs
+++ b/xtask/src/kernel/run.rs
@@ -7,6 +7,7 @@ pub struct RunConfig {
     pub enable_serial: bool,
     pub enable_disk: bool,
     pub enable_graphics: bool,
+    pub enable_qmp_socket: bool,
 }
 
 #[allow(dead_code)]
@@ -19,6 +20,7 @@ impl RunConfig {
             enable_serial: false,
             enable_graphics: true,
             enable_disk: true,
+            enable_qmp_socket: false,
         }
     }
 
@@ -44,6 +46,11 @@ impl RunConfig {
 
     pub fn with_disk(mut self, enable_disk: bool) -> Self {
         self.enable_disk = enable_disk;
+        self
+    }
+
+    pub fn with_qmp_socket(mut self, enable_qmp_socket: bool) -> Self {
+        self.enable_qmp_socket = enable_qmp_socket;
         self
     }
 
@@ -76,6 +83,10 @@ impl RunConfig {
 
         if !self.enable_graphics {
             cmd.arg("-display").arg("none");
+        }
+
+        if self.enable_qmp_socket {
+            cmd.arg("-qmp").arg("unix:./qmp-socket,server,nowait");
         }
 
         cmd.args(extra_args);

--- a/xtask/src/kernel/test.rs
+++ b/xtask/src/kernel/test.rs
@@ -17,7 +17,7 @@ pub fn build_test_kernel(meta: &GlobalMeta) -> anyhow::Result<PathBuf> {
         .arg("--message-format=json-render-diagnostics")
         .stdout(Stdio::piped());
 
-    println!("[+] Running: {:?}", cmd);
+    println!("[+] Running: {cmd:?}");
 
     let mut child = cmd.spawn()?;
 
@@ -33,7 +33,7 @@ pub fn build_test_kernel(meta: &GlobalMeta) -> anyhow::Result<PathBuf> {
                     .unwrap_or_default()
                     .lines()
                     .for_each(|line| {
-                        println!("{}", line);
+                        println!("{line}");
                     });
             }
             Message::CompilerArtifact(artifact) => {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,8 @@
+#![feature(trim_prefix_suffix)]
+
 mod args;
 mod kernel;
+mod profiler;
 mod toolchain;
 mod userspace;
 mod utils;
@@ -110,6 +113,9 @@ fn main() -> anyhow::Result<()> {
         },
         Command::Toolchain(toolchain) => {
             toolchain::dist(&meta, &toolchain)?;
+        }
+        Command::Profiler(sampler) => {
+            profiler::run(&meta, &sampler)?;
         }
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> anyhow::Result<()> {
                 println!("Test succeeded!");
                 std::process::exit(0);
             } else {
-                println!("Test failed! code: {}", code);
+                println!("Test failed! code: {code}");
                 std::process::exit(1);
             }
         }

--- a/xtask/src/profiler.rs
+++ b/xtask/src/profiler.rs
@@ -1,0 +1,408 @@
+use std::{
+    collections::HashMap,
+    io::{BufReader, Write},
+    ops::Range,
+    os::unix::net::UnixStream,
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use elf::endian::LittleEndian;
+use framehop::{
+    x86_64::{CacheX86_64, UnwindRegsX86_64, UnwinderX86_64},
+    ExplicitModuleSectionInfo, Module, Unwinder,
+};
+use qapi::{qmp, Qmp, Stream};
+
+use crate::{args::Profiler, GlobalMeta};
+
+#[derive(Debug)]
+struct SymbolCacheEntry {
+    address_range: Range<u64>,
+    symbol: String,
+}
+
+struct StackUnwinder {
+    // file_data: Box<[u8]>,
+    symbols: Vec<SymbolCacheEntry>,
+    unwinder: UnwinderX86_64<Vec<u8>>,
+    cache: CacheX86_64,
+}
+
+impl StackUnwinder {
+    pub fn new<P: AsRef<Path>>(kernel_file: P) -> anyhow::Result<Self> {
+        let file_data = std::fs::read(kernel_file)?.into_boxed_slice();
+        let file_data_slice = &file_data[..];
+
+        let elf_file = elf::ElfBytes::<LittleEndian>::minimal_parse(file_data_slice)
+            .map_err(|e| anyhow::anyhow!("Failed to parse ELF file: {}", e))?;
+
+        let text_section = elf_file
+            .section_header_by_name(".text")?
+            .ok_or_else(|| anyhow::anyhow!("ELF file does not contain a .text section"))?;
+        let eh_frame_section = elf_file
+            .section_header_by_name(".eh_frame")?
+            .ok_or_else(|| anyhow::anyhow!("ELF file does not contain a .eh_frame section"))?;
+
+        println!(
+            "Found .text section at {:#x} with size {}",
+            text_section.sh_addr, text_section.sh_size
+        );
+
+        println!(
+            "Found .eh_frame section at {:#x} with size {}",
+            eh_frame_section.sh_addr, eh_frame_section.sh_size
+        );
+
+        let module = Module::new(
+            String::from("kernel"),
+            0xFFFFFFFF80100000..0xffffffff80FFFFFF,
+            0xFFFFFFFF80100000,
+            ExplicitModuleSectionInfo {
+                base_svma: 0xFFFFFFFF80100000,
+                text_svma: Some(
+                    text_section.sh_addr as u64
+                        ..(text_section.sh_addr + text_section.sh_size) as u64,
+                ),
+                text: Some(
+                    file_data_slice[text_section.sh_offset as usize
+                        ..(text_section.sh_offset + text_section.sh_size) as usize]
+                        .to_vec(),
+                ),
+                eh_frame_svma: Some(
+                    eh_frame_section.sh_addr as u64
+                        ..(eh_frame_section.sh_addr + eh_frame_section.sh_size) as u64,
+                ),
+                eh_frame: Some(
+                    file_data_slice[eh_frame_section.sh_offset as usize
+                        ..(eh_frame_section.sh_offset + eh_frame_section.sh_size) as usize]
+                        .to_vec(),
+                ),
+                ..Default::default()
+            },
+        );
+
+        let cache = CacheX86_64::new();
+        let mut unwinder: UnwinderX86_64<Vec<u8>> = UnwinderX86_64::new();
+        unwinder.add_module(module);
+
+        // Initialize symbols
+        let mut symbols = Vec::new();
+        if let Some(symbol_table) = elf_file.symbol_table()? {
+            for symbol in symbol_table.0.iter() {
+                if symbol.st_shndx != 0 && symbol.st_size > 0 {
+                    let start_addr = symbol.st_value;
+                    let end_addr = start_addr + symbol.st_size;
+
+                    let name = symbol_table.1.get(symbol.st_name as usize)?;
+                    symbols.push(SymbolCacheEntry {
+                        address_range: start_addr..end_addr,
+                        symbol: rustc_demangle::demangle(name).to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(StackUnwinder {
+            symbols,
+            unwinder,
+            cache,
+        })
+    }
+
+    pub fn unwind_stack<F>(&mut self, rip: u64, rsp: u64, rbp: u64, read_stack: &mut F) -> Vec<u64>
+    where
+        F: FnMut(u64) -> Result<u64, ()>,
+    {
+        let regs = UnwindRegsX86_64::new(rip, rsp, rbp);
+        let mut iter = self
+            .unwinder
+            .iter_frames(rip, regs, &mut self.cache, read_stack);
+
+        let mut frames = Vec::new();
+        while let Ok(Some(frame)) = iter.next() {
+            frames.push(frame.address());
+        }
+        frames
+    }
+
+    pub fn resolve_symbol(&self, address: u64) -> anyhow::Result<String> {
+        for entry in &self.symbols {
+            if entry.address_range.contains(&address) {
+                return Ok(entry.symbol.clone());
+            }
+        }
+
+        Ok(format!("<unknown:0x{:x}>", address))
+    }
+}
+
+struct Sampler<'a> {
+    qmp: Qmp<Stream<BufReader<&'a UnixStream>, &'a UnixStream>>,
+    unwinder: StackUnwinder,
+}
+
+fn hex_to_u64(hex_str: &str) -> anyhow::Result<u64> {
+    u64::from_str_radix(hex_str.trim().trim_start_matches("0x"), 16)
+        .map_err(|e| anyhow::anyhow!("Failed to parse hex string '{}': {}", hex_str, e))
+}
+
+impl<'a> Sampler<'a> {
+    pub fn new(
+        qmp: Qmp<Stream<BufReader<&'a UnixStream>, &'a UnixStream>>,
+        unwinder: StackUnwinder,
+    ) -> Self {
+        Sampler { qmp, unwinder }
+    }
+
+    pub fn get_registers(&mut self, verbose: bool) -> anyhow::Result<(u64, u64, u64)> {
+        let regs = self.qmp.execute(&qmp::human_monitor_command {
+            cpu_index: Some(0),
+            command_line: format!("info registers"),
+        })?;
+
+        if verbose {
+            println!("Registers: {}", regs);
+        }
+
+        let get_reg = |name: &str| -> anyhow::Result<u64> {
+            hex_to_u64(
+                regs.split_once(name)
+                    .ok_or(anyhow::anyhow!("Failed to find {name} in registers"))?
+                    .1
+                    .split_ascii_whitespace()
+                    .next()
+                    .ok_or(anyhow::anyhow!("Failed to parse {name} value"))?,
+            )
+        };
+
+        let rip = get_reg("RIP=")?;
+        let rsp = get_reg("RSP=")?;
+        let rbp = get_reg("RBP=")?;
+
+        Ok((rip, rsp, rbp))
+    }
+
+    pub fn get_stack_symbols(
+        &self,
+        stack: &[u64],
+        show_addresses: bool,
+    ) -> anyhow::Result<Vec<String>> {
+        let mut symbols = Vec::new();
+
+        for &address in stack {
+            let symbol = self.unwinder.resolve_symbol(address)?;
+
+            if show_addresses {
+                symbols.push(format!("{} [0x{:x}]", symbol, address));
+            } else {
+                symbols.push(symbol);
+            }
+        }
+
+        Ok(symbols)
+    }
+
+    pub fn sample_with_timing(&mut self, verbose: bool) -> anyhow::Result<(Vec<u64>, Duration)> {
+        let start_time = Instant::now();
+
+        self.qmp.execute(&qmp::stop {})?;
+
+        let (rip, rsp, rbp) = self.get_registers(verbose)?;
+
+        let result = self.unwinder.unwind_stack(rip, rsp, rbp, &mut |addr| {
+            let register_read = self
+                .qmp
+                .execute(&qmp::human_monitor_command {
+                    cpu_index: Some(0),
+                    command_line: format!("x/1gx {:#x}", addr),
+                })
+                .map_err(|_| ())?;
+
+            let value = register_read.split(": ").nth(1).ok_or(())?;
+
+            hex_to_u64(value).map_err(|_| ())
+        });
+
+        self.qmp.execute(&qmp::cont {})?;
+        let total_time = start_time.elapsed();
+
+        Ok((result, total_time))
+    }
+}
+
+pub fn run(meta: &GlobalMeta, args: &Profiler) -> anyhow::Result<()> {
+    let kernel_path = meta
+        .target_path
+        .join(meta.profile_path())
+        .join("iso")
+        .join("boot")
+        .join("kernel");
+    assert!(kernel_path.exists(), "Kernel ELF file does not exist");
+
+    let unwinder = StackUnwinder::new(&kernel_path)?;
+
+    let socket = UnixStream::connect(&args.qmp_socket)
+        .map_err(|e| anyhow::anyhow!("Failed to connect to socket: {}", e))?;
+
+    let mut qmp = qapi::Qmp::from_stream(&socket);
+
+    let info = qmp.handshake()?;
+    if args.verbose {
+        println!("QMP Info: {:?}", info);
+    }
+
+    let mut sampler = Sampler::new(qmp, unwinder);
+
+    // Handle single sample case (when duration is 0 or very short)
+    if args.duration_sec < 1 || args.one_shot {
+        let (stack, took) = sampler.sample_with_timing(args.verbose)?;
+        let symbols = sampler.get_stack_symbols(&stack, args.show_addresses)?;
+
+        println!("Current stack trace (took {took:?}:");
+        for (i, symbol) in symbols.iter().enumerate() {
+            println!("{:>3}: {}", i, symbol);
+        }
+        return Ok(());
+    }
+
+    // Continuous or timed sampling
+    let mut sample_counts: HashMap<String, usize> = HashMap::new();
+    let mut total_samples = 0;
+    let mut failed_samples = 0;
+    let mut total_sample_time = Duration::ZERO;
+    let mut total_symbol_time = Duration::ZERO;
+
+    let interval_duration = Duration::from_millis(args.interval_ms);
+    let start_time = Instant::now();
+    let end_time = start_time + Duration::from_secs(args.duration_sec);
+
+    println!("Starting stack sampling...");
+    if args.verbose {
+        println!("Interval: {}ms", args.interval_ms);
+        println!("Duration: {}s", args.duration_sec);
+    }
+
+    loop {
+        if Instant::now() >= end_time {
+            if args.verbose {
+                println!("Reached time limit");
+            }
+            break;
+        }
+
+        let interval_start = Instant::now();
+
+        // Take a sample
+        match sampler.sample_with_timing(args.verbose) {
+            Ok((stack, sample_time)) => {
+                total_sample_time += sample_time;
+
+                if !stack.is_empty() {
+                    let symbol_start = Instant::now();
+                    match sampler.get_stack_symbols(&stack, false) {
+                        Ok(mut symbols) => {
+                            // Create folded stack format (root to leaf)
+                            symbols.reverse();
+                            let folded_stack = symbols.join(";");
+                            *sample_counts.entry(folded_stack).or_insert(0) += 1;
+                            total_samples += 1;
+
+                            if args.verbose {
+                                println!("Sample {}: {} frames", total_samples, stack.len());
+                            }
+                        }
+                        Err(e) => {
+                            failed_samples += 1;
+                            if args.verbose {
+                                println!("Failed to resolve symbols: {}", e);
+                            }
+                        }
+                    }
+                    total_symbol_time += Instant::now() - symbol_start;
+                } else {
+                    failed_samples += 1;
+                    if args.verbose {
+                        println!("Empty stack trace");
+                    }
+                }
+            }
+            Err(e) => {
+                failed_samples += 1;
+                if args.verbose {
+                    println!("Failed to sample stack: {}", e);
+                }
+            }
+        }
+
+        // Sleep for the remaining interval time
+        let elapsed = interval_start.elapsed();
+        if elapsed < interval_duration {
+            std::thread::sleep(interval_duration - elapsed);
+        } else if args.verbose {
+            println!(
+                "Warning: Sampling took longer than interval ({:?} > {:?})",
+                elapsed, interval_duration
+            );
+        }
+    }
+
+    let total_elapsed = start_time.elapsed();
+
+    // Print statistics
+    println!("\n=== Sampling Statistics ===");
+    println!("Total samples: {}", total_samples);
+    println!("Failed samples: {}", failed_samples);
+    println!("Unique stacks: {}", sample_counts.len());
+    println!("Total time: {:?}", total_elapsed);
+    if total_samples > 0 {
+        println!(
+            "Average sample time: {:?}",
+            total_sample_time / total_samples as u32
+        );
+        println!("Total sample time: {:?}", total_sample_time);
+        println!(
+            "Average symbol resolution time: {:?}",
+            total_symbol_time / total_samples as u32
+        );
+        println!("Total symbol resolution time: {:?}", total_symbol_time);
+        println!(
+            "Success rate: {:.1}%",
+            (total_samples as f64 / (total_samples + failed_samples) as f64) * 100.0
+        );
+    }
+
+    // Write output file if specified
+    if let Some(output_path) = &args.output {
+        println!("Writing {} samples to {}", sample_counts.len(), output_path);
+
+        let mut file = std::fs::File::create(output_path)?;
+        for (stack, count) in sample_counts.iter() {
+            writeln!(file, "{} {}", stack, count)?;
+        }
+
+        println!("Folded stack samples written to: {}", output_path);
+        println!(
+            "Generate flamegraph with: flamegraph.pl {} > flamegraph.svg",
+            output_path
+        );
+    } else {
+        // Print top stacks
+        let mut sorted_stacks: Vec<_> = sample_counts.iter().collect();
+        sorted_stacks.sort_by(|a, b| b.1.cmp(a.1));
+
+        println!("\n=== Top Stack Traces ===");
+        for (i, (stack, count)) in sorted_stacks.iter().take(10).enumerate() {
+            let percentage = (**count as f64 / total_samples as f64) * 100.0;
+            println!(
+                "{:>2}. ({:>3} samples, {:>5.1}%) {}",
+                i + 1,
+                count,
+                percentage,
+                stack
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/xtask/src/toolchain.rs
+++ b/xtask/src/toolchain.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use crate::{
+    GlobalMeta,
     args::Toolchain,
     utils::{copy_files, run_cmd},
-    GlobalMeta,
 };
 
 // make sure we have the submodule checked out

--- a/xtask/src/userspace.rs
+++ b/xtask/src/userspace.rs
@@ -3,9 +3,9 @@ pub mod check;
 use cargo_metadata::Package;
 
 use crate::{
+    GlobalMeta,
     args::Build,
     utils::{copy_files, has_changed, run_cmd},
-    GlobalMeta,
 };
 
 const TARGET: &str = "x86_64-unknown-emerald";

--- a/xtask/src/userspace.rs
+++ b/xtask/src/userspace.rs
@@ -34,7 +34,7 @@ fn check_toolchain_installed(meta: &GlobalMeta) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn userspace_output_path(meta: &GlobalMeta, name: &str) -> std::path::PathBuf {
+pub(crate) fn userspace_output_path(meta: &GlobalMeta, name: &str) -> std::path::PathBuf {
     meta.target_path
         .join(TARGET)
         .join(meta.profile_path())

--- a/xtask/src/userspace/check.rs
+++ b/xtask/src/userspace/check.rs
@@ -1,6 +1,6 @@
 use crate::{
-    args::{Check, Clippy, Fmt},
     GlobalMeta,
+    args::{Check, Clippy, Fmt},
 };
 
 use super::{check_toolchain_installed, run_for_all_userspace_members};

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -49,8 +49,8 @@ pub fn copy_files(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> anyhow::Resul
     let src = src.as_ref();
     let mut dst = dst.as_ref().to_owned();
 
-    assert!(src.exists(), "Source path does not exist: {:?}", src);
-    assert!(!src.is_dir(), "Source path is not a file: {:?}", src);
+    assert!(src.exists(), "Source path does not exist: {src:?}");
+    assert!(!src.is_dir(), "Source path is not a file: {src:?}");
 
     if dst.is_dir() {
         let file_name = src.file_name().unwrap();
@@ -65,14 +65,14 @@ pub fn copy_files(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> anyhow::Resul
         return Ok(());
     }
 
-    println!("[+] Copying {:?} to {:?}", src, dst);
+    println!("[+] Copying {src:?} to {dst:?}");
     std::fs::copy(src, dst)?;
 
     Ok(())
 }
 
 pub fn run_cmd(mut cmd: std::process::Command) -> anyhow::Result<()> {
-    println!("[+] Running: {:?}", cmd);
+    println!("[+] Running: {cmd:?}");
 
     let status = cmd.status()?;
 


### PR DESCRIPTION
## Summary

<!-- Please provide a brief description of the changes made in this PR -->

Add profiling support for the kernel through qemu and qmp protocl

This works by attacking to `qmp` socket and fetching the current stack by using `gdb` commands through qemu.
Then we get a `stack.folded` file where we can generate flamegraph with or use it in https://www.speedscope.app/

This now will make profiling and optimizing the OS so much simpler

### Related issue

<!-- Mention any relevant issues like #123 -->

- [x] #118 (even though this wasn't the intended way, but this works so well)
- [x] #119 (~~this kinda implements userspace profiling as well, but I don't like it so much so I won't make it finished~~)
    - actually, turns out, we can implement very robust and nice userspace profiling, I would say userspace profiling is also done, but maybe for the future, let's make a profiler in our kernel that will profile userspace processes only.

## Changes

<!-- Please provide some more detail regarding the changes.
Add any additional information, configuration, or data that might be necessary for the review
Mention the type of each change. i.e. `Addition`, `Bug Fix`, `Documentation`, etc... -->

- Add `xtask profile` command where it will attach to `./qmp-socket` that was created by `xtask --profile run` and gives
  a summary or `stack.folded` (with `-o` parameter)
- Right now we made `xtask` run as `--release` by default because tracing require a bit of performance.
- Fixed unwinding in `rust`

## Checklist

- [x] The changes are tested and works as expected (mention if not)
- [x] Tests if applicable (new features, regression tests, etc...)
- [x] Documentation
- [ ] Needed README changes
